### PR TITLE
Fix Jackson LocalDate Serialization

### DIFF
--- a/server/src/main/java/de/coronavirus/imis/config/PersistanceConfig.java
+++ b/server/src/main/java/de/coronavirus/imis/config/PersistanceConfig.java
@@ -18,10 +18,4 @@ class PersistenceConfig {
 	public AuditorAware<User> auditorAware() {
 		return new AuditorAwareImpl();
 	}
-
-	@Bean
-	public ObjectMapper objectMapper() {
-		return new ObjectMapper().disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
-	}
-
 }

--- a/server/src/main/resources/application.yml
+++ b/server/src/main/resources/application.yml
@@ -15,6 +15,9 @@ spring:
     password: password
     initialization-mode: always
     platform: postgres
+  jackson:
+    serialization:
+      FAIL_ON_EMPTY_BEANS: false
   jpa:
     show-sql: true
     hibernate:
@@ -59,5 +62,3 @@ spring:
     gcp:
       storage:
         enabled: false
-
-


### PR DESCRIPTION
Closes #292 

Due to previous code additions, the default Spring-provided Jackson `ObjectMapper` has been overridden. Since `ObjectMapper` overrides are not subject to Spring's `ObjectMapper` preconfiguration, the new `ObjectMapper` instance in use has been lacking config settings and extension modules that previously have been in operation. This Pull Request removes the `ObjectMapper` bean causing this trouble while ensuring the configuration enforced by that specific bean is preserved using the application configuration file `application.yml`.
