### PR TITLE
#281 Add patient name to top of patient details view

### DIFF
--- a/client/src/models/event-types.ts
+++ b/client/src/models/event-types.ts
@@ -4,6 +4,7 @@ export interface EventTypeItem {
   id: PatientStatus;
   label: string;
   icon: string;
+  color: string;
 }
 
 export const eventTypes: EventTypeItem[] = [
@@ -11,55 +12,68 @@ export const eventTypes: EventTypeItem[] = [
     id: 'REGISTERED',
     label: 'Registriert',
     icon: 'login',
+    color: 'blue',
   }, {
     id: 'SUSPECTED',
     label: 'Verdachtsfall',
     icon: 'search',
+    color: 'purple',
   }, {
     id: 'ORDER_TEST',
     label: 'Test angefordert',
     icon: 'experiment',
+    color: 'aqua',
   }, {
     id: 'SCHEDULED_FOR_TESTING',
     label: 'Wartet auf Test',
     icon: 'team',
+    color: 'purple',
   }, {
     id: 'TEST_SUBMITTED_IN_PROGRESS',
     label: 'Test eingereicht',
     icon: 'clock-circle',
+    color: 'purple',
   }, {
     id: 'TEST_FINISHED_POSITIVE',
     label: 'Test positiv',
     icon: 'check',
+    color: 'red',
   }, {
     id: 'TEST_FINISHED_NEGATIVE',
     label: 'Test negativ',
     icon: 'stop',
+    color: 'green',
   }, {
     id: 'TEST_FINISHED_INVALID',
     label: 'Test invalide',
     icon: 'warning',
+    color: 'gold',
   }, {
     id: 'TEST_FINISHED_RECOVERED',
     label: 'Getestet und erholt',
     icon: 'rollback',
+    color: 'green',
   }, {
     id: 'TEST_FINISHED_NOT_RECOVERED',
     label: 'Getestet und nicht erholt',
     icon: 'logout',
+    color: 'red',
   }, {
     id: 'PATIENT_DEAD',
     label: 'Verstorben',
     icon: 'cloud',
+    color: 'gray',
   }, {
     id: 'DOCTORS_VISIT',
     label: 'Arztbesuch',
     icon: 'reconciliation',
+    color: 'blue',
   },
   {
     id: 'QUARANTINE_MANDATED',
     label: 'Quarantäne angeordnet',
     icon: 'safety',
+    color: 'palevioletred',
   },
 ]
 

--- a/client/src/views/PatientDetails.vue
+++ b/client/src/views/PatientDetails.vue
@@ -1,95 +1,90 @@
-<template style="margin: auto">
+<template style="margin: auto;">
   <div>
     <ChangePatientStammdatenForm
-      @cancel="() => { showChangePatientStammdatenForm = false }"
-      @create="() => { showChangePatientStammdatenForm = false; this.loadData() }"
+      @cancel="
+        () => {
+          showChangePatientStammdatenForm = false;
+        }
+      "
+      @create="
+        () => {
+          showChangePatientStammdatenForm = false;
+          this.loadData();
+        }
+      "
       :visible="showChangePatientStammdatenForm"
       :patient="patient"
     />
-    <div style="max-width: 1020px; margin: 0 auto; padding: 0 1rem">
-      <a-tabs
-        defaultActiveKey="1"
-        v-if="patient"
+    <div style="max-width: 1020px; margin: 0 auto; padding: 1rem 1rem; text-align: left;">
+      <a-page-header
+        :title="`${patient.lastName}, ${patient.firstName}`"
+        :sub-title="patient.id"
+        @back="() => $router.go(-1)"
+        style="padding: 1rem 0;"
       >
-        <a-tab-pane
-          key="1"
-          tab="Falldaten"
-        >
-          <div style="display: flex; justify-content: flex-end; padding-bottom: 10px">
-            <div style="padding-right: 1rem">
-              <a-dropdown>
-                <a-menu slot="overlay" @click="handleActionClick">
-                  <a-menu-item key="ARRANGE_TEST">
-                    <a-icon type="user" />
-                    Neuen Test anordnen
-                  </a-menu-item>
-                  <a-menu-item key="SEND_TO_QUARANTINE">
-                    <a-icon type="user" />
-                    Patienten in Quarantäne schicken
-                  </a-menu-item>
-                  <!--                <a-menu-item key="HOSPITALIZATION"><a-icon type="user" />Krankenhaus einweisung</a-menu-item>-->
-                </a-menu>
-                <a-button style="margin-left: 8px" type="primary"> Aktionen
-                  <a-icon type="down" />
-                </a-button>
-              </a-dropdown>
-            </div>
-            <a-button type="primary" icon="edit" @click="editPatientStammdaten">
-              Daten ändern
+        <template slot="tags">
+          <a-tag :color="patientStatus.color" v-if="patientStatus">
+            {{ patientStatus.label }}
+          </a-tag>
+        </template>
+        <template slot="extra">
+          <a-dropdown>
+            <a-menu slot="overlay" @click="handleActionClick">
+              <a-menu-item key="ARRANGE_TEST"> <a-icon type="user" />Neuen Test anordnen </a-menu-item>
+              <a-menu-item key="SEND_TO_QUARANTINE">
+                <a-icon type="user" />Patienten in Quarantäne schicken
+              </a-menu-item>
+              <!--                <a-menu-item key="HOSPITALIZATION"><a-icon type="user" />Krankenhaus einweisung</a-menu-item>-->
+            </a-menu>
+            <a-button style="margin-left: 8px;">
+              Aktionen
+              <a-icon type="down" />
             </a-button>
-          </div>
-          <!-- display user data here-->
-          <div>
+          </a-dropdown>
+        </template>
+      </a-page-header>
 
-            <!-- Allgemein & Adresse -->
+      <a-tabs defaultActiveKey="1" v-if="patient">
+        <a-tab-pane key="1" tab="Stammdaten">
+          <div>
+            <a-row type="flex" justify="end" style="margin-bottom: 1rem;">
+              <a-col>
+                <a-button icon="edit" @click="editPatientStammdaten">Daten ändern</a-button>
+              </a-col>
+            </a-row>
             <a-row :gutter="8">
-              <a-col
-                :md="12"
-                :span="24"
-              >
-                <a-card
-                  :extra="this.patient.id"
-                  align="left"
-                  title="Allgemein"
-                >
+              <a-col :md="12" :span="24">
+                <a-card :extra="patient.id" align="left" title="Allgemein">
                   <table>
                     <tr>
-                      <td>Name:</td>
-                      <td>{{patient.lastName}}, {{patient.firstName}}</td>
+                      <td>Geburtsdatum:</td>
+                      <td>{{ dateOfBirth }}</td>
                     </tr>
                     <tr>
-                      <td>Geburtsdatum:</td>
-                      <td>{{dateOfBirth}}</td>
                       <td>Geschlecht:</td>
-                      <td>{{gender}}</td>
+                      <td>{{ gender }}</td>
                     </tr>
                     <tr>
                       <td>Staatsangehörigkeit:</td>
-                      <td>{{patient.nationality}}</td>
+                      <td>{{ patient.nationality }}</td>
                     </tr>
                   </table>
                 </a-card>
               </a-col>
-              <a-col
-                :md="12"
-                :span="24"
-              >
-                <a-card
-                  align="left"
-                  title="Adresse"
-                >
+              <a-col :md="12" :span="24">
+                <a-card align="left" title="Adresse">
                   <table>
                     <tr>
                       <td>Straße/Hausnr.:</td>
-                      <td>{{patient.street}} {{patient.houseNumber}}</td>
+                      <td>{{ patient.street }} {{ patient.houseNumber }}</td>
                     </tr>
                     <tr>
                       <td>PLZ/Ort:</td>
-                      <td>{{patient.zip}} {{patient.city}}</td>
+                      <td>{{ patient.zip }} {{ patient.city }}</td>
                     </tr>
                     <tr>
                       <td>Land:</td>
-                      <td>{{patient.country}}</td>
+                      <td>{{ patient.country }}</td>
                     </tr>
                   </table>
                 </a-card>
@@ -99,88 +94,85 @@
             <!-- Kontakt & Versicherung & Arbeitgeber -->
             <a-row :gutter="8" style="margin-top: 8px;">
               <a-col :md="8" :span="24">
-                <a-card
-                  align="left"
-                  title="Kontakt"
-                >
+                <a-card align="left" title="Kontakt">
                   <table>
                     <tr>
                       <td>Telefonnummer:</td>
-                      <td>{{patient.phoneNumber}}</td>
+                      <td>{{ patient.phoneNumber }}</td>
                     </tr>
                     <tr>
                       <td>Email:</td>
-                      <td><a href="">{{patient.email}}</a></td>
+                      <td>
+                        <a :href="`mailto:${patient.email}`">{{ patient.email }}</a>
+                      </td>
                     </tr>
                   </table>
                 </a-card>
               </a-col>
               <a-col :md="8" :span="24">
-                <a-card
-                  align="left"
-                  title="Versicherung"
-                >
+                <a-card align="left" title="Versicherung">
                   <table>
                     <tr>
                       <td>Versicherung:</td>
-                      <td>{{patient.insuranceCompany}}</td>
+                      <td>{{ patient.insuranceCompany }}</td>
                     </tr>
                     <tr>
                       <td>V-Nr:</td>
-                      <td>{{patient.insuranceMembershipNumber}}</td>
+                      <td>{{ patient.insuranceMembershipNumber }}</td>
                     </tr>
                   </table>
                 </a-card>
               </a-col>
               <a-col :md="8" :span="24">
-                <a-card
-                  align="left"
-                  title="Arbeit"
-                >
+                <a-card align="left" title="Arbeit">
                   <table>
                     <tr>
                       <td>Beruf:</td>
-                      <td>{{patient.occupation || 'Keine Angabe'}}</td>
+                      <td>{{ patient.occupation || "Keine Angabe" }}</td>
                     </tr>
                     <tr>
                       <td>Arbeitgeber:</td>
-                      <td>{{patient.employer || 'Keine Angabe'}}</td>
+                      <td>{{ patient.employer || "Keine Angabe" }}</td>
                     </tr>
                   </table>
                 </a-card>
               </a-col>
             </a-row>
-
+          </div>
+        </a-tab-pane>
+        <a-tab-pane key="2" tab="Falldaten">
+          <!-- display user data here-->
+          <div>
             <!-- Tests -->
             <a-row :gutter="8" style="margin-top: 8px;">
               <a-col span="24">
-                <div style="background: white; border: 1px solid #e8e8e8">
+                <div style="background: white; border: 1px solid #e8e8e8;">
                   <div class="card-header">
                     <div>
-                      Fall-Status: {{(patientStatus ? patientStatus.label : 'Unbekannt') + (patient.quarantineUntil ?
-                      (', Quarantäne angeordnet bis ' + patient.quarantineUntil) : '')}}"
+                      Fall-Status: {{ patientStatus ? patientStatus.label : 'Unbekannt' }}
+                      {{patient.quarantineUntil ? ", Quarantäne angeordnet bis " + patient.quarantineUntil : "" }}
                     </div>
-                    <div class="card-header-subtitle">Erkrankungsdatum: {{dateOfIllness}}</div>
-                    <div class="card-header-subtitle">Meldedatum: {{dateOfReporting}}</div>
+                    <div class="card-header-subtitle">Erkrankungsdatum: {{ dateOfIllness }}</div>
+                    <div class="card-header-subtitle">Meldedatum: {{ dateOfReporting }}</div>
                   </div>
                   <a-table
                     :columns="columnsTests"
                     :dataSource="tests"
-                    :scroll="{x: 0, y: 0}"
+                    :scroll="{ x: 0, y: 0 }"
                     class="imis-table-no-pagination"
                     rowKey="id"
-                    style="padding: 0 24px"
                   >
-                    <div slot="lastUpdate" slot-scope="lastUpdate">
-                      {{getDate(lastUpdate)}}
-                    </div>
+                    <div slot="lastUpdate" slot-scope="lastUpdate">{{ getDate(lastUpdate) }}</div>
                     <div slot="testStatus" slot-scope="testStatus">
-                      <a-icon :type="testResults.find(type => type.id === testStatus).icon" style="margin-right: 5px" />
-                      {{testResults.find(type => type.id === testStatus).label}}
+                      <a-icon
+                        :type="testResults.find((type) => type.id === testStatus).icon"
+                        style="margin-right: 5px;"
+                      />
+                      {{ testResults.find((type) => type.id === testStatus).label }}
                     </div>
                     <div slot="testType" slot-scope="testType">
-                      <a-icon :type="testTypes.find(type => type.id === testType).icon" style="margin-right: 5px" />
-                      {{testTypes.find(type => type.id === testType).label}}
+                      <a-icon :type="testTypes.find((type) => type.id === testType).icon" style="margin-right: 5px;" />
+                      {{ testTypes.find((type) => type.id === testType).label }}
                     </div>
                   </a-table>
                 </div>
@@ -189,43 +181,23 @@
 
             <!-- Symptome und Risiken -->
             <a-row :gutter="8" style="margin-top: 8px;">
-              <a-col
-                :md="12"
-                :span="24"
-              >
-                <a-card
-                  align="left"
-                  title="Vorerkrankungen und Risikofaktoren"
-                >
-                  <div v-bind:key="illness" v-for="illness in preIllnesses">{{illness}}</div>
+              <a-col :md="12" :span="24">
+                <a-card align="left" title="Vorerkrankungen und Risikofaktoren">
+                  <div v-bind:key="illness" v-for="illness in preIllnesses">{{ illness }}</div>
                 </a-card>
               </a-col>
-              <a-col
-                :md="12"
-                :span="24"
-              >
-                <a-card
-                  :extra="'Stand: ' + formatTimestamp(patient.creationTimestamp)"
-                  align="left"
-                  title="Symptome"
-                >
-                  <div v-bind:key="symptom" v-for="symptom in symptoms">{{symptom}}</div>
+              <a-col :md="12" :span="24">
+                <a-card :extra="'Stand: ' + formatTimestamp(patient.creationTimestamp)" align="left" title="Symptome">
+                  <div v-bind:key="symptom" v-for="symptom in symptoms">{{ symptom }}</div>
                 </a-card>
               </a-col>
             </a-row>
           </div>
-          <br>
+          <br />
         </a-tab-pane>
-        <a-tab-pane
-          forceRender
-          key="2"
-          tab="Verlauf"
-        >
+        <a-tab-pane forceRender key="3" tab="Verlauf">
           <a-card>
-            <a-timeline
-              style="text-align: left; margin-left: 40px"
-              v-if="patient.events.length"
-            >
+            <a-timeline style="text-align: left; margin-left: 40px;" v-if="patient.events.length">
               <!-- List all the events recorded corresponding to the patient over time -->
               <a-timeline-item
                 :color="timelineColor(event.eventType)"
@@ -233,7 +205,7 @@
                 v-for="event in this.patient.events"
               >
                 {{ formatTimestamp(event.eventTimestamp) }},
-                {{ eventTypes.find(type => type.id === event.eventType).label }}
+                {{ eventTypes.find((type) => type.id === event.eventType).label }}
               </a-timeline-item>
             </a-timeline>
           </a-card>
@@ -261,28 +233,32 @@ const columnsTests: Partial<Column>[] = [
     title: 'Test ID',
     dataIndex: 'testId',
     key: 'testId',
-  }, {
+  },
+  {
     title: 'Test Typ',
     dataIndex: 'testType',
     key: 'testType',
     scopedSlots: {
       customRender: 'testType',
     },
-  }, {
+  },
+  {
     title: 'Test Status',
     dataIndex: 'testStatus',
     key: 'testStatus',
     scopedSlots: {
       customRender: 'testStatus',
     },
-  }, {
+  },
+  {
     title: 'Aktualisiert',
     dataIndex: 'lastUpdate',
     key: 'lastUpdate',
     scopedSlots: {
       customRender: 'lastUpdate',
     },
-  }, {
+  },
+  {
     title: 'Kommentar',
     dataIndex: 'comment',
     key: 'comment',


### PR DESCRIPTION
This pull request will display the patient name in the top section of the patient details view. 

Furthermore I have:
- moved patient's master data (address, contact, insurance, etc.) to a dedicated tab
- added a color attribute to event types to be used e.g. as tag colors (this is just a suggestion)

Closes #281 