### PR TITLE
Fix Selbstregistrierung

### DIFF
--- a/server/src/main/java/de/coronavirus/imis/config/AuditorAwareImpl.java
+++ b/server/src/main/java/de/coronavirus/imis/config/AuditorAwareImpl.java
@@ -13,7 +13,9 @@ public class AuditorAwareImpl implements AuditorAware<User> {
 
 		Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
 
-		if(authentication != null && SecurityContextHolder.getContext().getAuthentication().isAuthenticated())
+		if(authentication != null
+				&& SecurityContextHolder.getContext().getAuthentication().isAuthenticated()
+				&& authentication.getPrincipal()!="anonymousUser")
 		{
 			var user = (User) authentication.getPrincipal();
 			Optional<User> opt = Optional.of(user);

--- a/server/src/main/java/de/coronavirus/imis/config/SpringSecurityConfig.java
+++ b/server/src/main/java/de/coronavirus/imis/config/SpringSecurityConfig.java
@@ -61,6 +61,7 @@ public class SpringSecurityConfig extends WebSecurityConfigurerAdapter {
 				// OPTIONS matcher for CORS, do not delete
 				.antMatchers(OPTIONS, "/**").permitAll()
 				.antMatchers("/api/auth").permitAll()
+				.mvcMatchers(POST, API_PREFIX + "/patients").permitAll()
 				.antMatchers(API_PREFIX + "/patients").hasAnyRole(DEPARTMENT_OF_HEALTH, CLINIC, DOCTORS_OFFICE, TEST_SITE)
 				.antMatchers(API_PREFIX + "/patients/quarantine/*").hasAnyRole(DEPARTMENT_OF_HEALTH)
 				.antMatchers(API_PREFIX + "/exposure-contacts/**").hasAnyRole(DEPARTMENT_OF_HEALTH, CLINIC, DOCTORS_OFFICE, TEST_SITE)


### PR DESCRIPTION
Die Selbstregistrierung erfordert Zugriff auf addPatient ohne dass eine Rolle vergeben ist.
addPatient ist derzeit das einzige POST-Mapping unter /api/patients, daher ist die hier vorgeschlagene Änderung vorläufig eine Lösung.

Über einen separaten Endpoint für die Selbstregistrierung oder die Wiedereinführung von @PreAuthorize könnte man nachdenken.