### PR TITLE
Improvements on clientside form utilities (code & docs)

### DIFF
--- a/client/src/components/EditExposureContact.vue
+++ b/client/src/components/EditExposureContact.vue
@@ -3,7 +3,7 @@
     <a-form-item style="display: none;"
       :selfUpdate="true">
       <a-input type="hidden"
-        v-decorator="[ formInputKey('id') ]"/>
+        v-decorator="[ formFieldName('id') ]"/>
     </a-form-item>
     <a-row class="patients-flex">
       <!-- Originating and Contact Names -->
@@ -16,7 +16,7 @@
           v-bind="inputProps.source"
           :disabled="$props.disableOriginatorPatient"
           :filterOption="filterSources"
-          v-decorator="[ formInputKey('source'), {
+          v-decorator="[ formFieldName('source'), {
               rules: [
                 { required: true, message: 'Bitte Ursprungspatienten angeben' },
               ],
@@ -34,7 +34,7 @@
           v-bind="inputProps.contact"
           :disabled="$props.disableContactPatient"
           :filterOption="filterContacts"
-          v-decorator="[ formInputKey('contact'), {
+          v-decorator="[ formFieldName('contact'), {
               rules: [
                 { required: true, message: 'Bitte Kontaktperson angeben' },
               ],
@@ -49,7 +49,7 @@
           <date-input
             v-bind="inputProps.dateOfContact"
             :disabledDate="date => date.isAfter(moment())"
-            v-decorator="[ formInputKey('dateOfContact'), {
+            v-decorator="[ formFieldName('dateOfContact'), {
               rules: [
                 { required: true, message: 'Bitte ein gültiges Datum angeben' },
               ],
@@ -64,7 +64,7 @@
             v-bind="inputProps.context"
             :dataSource="contexts"
             :filterOption="false"
-            v-decorator="[ formInputKey('context'), {
+            v-decorator="[ formFieldName('context'), {
               rules: [
                 { required: true, message: 'Bitte den Umstand des Kontakts angeben' }
               ]
@@ -78,7 +78,7 @@
         :selfUpdate="true">
         <a-textarea
           v-bind="inputProps.comment"
-          v-decorator="[ formInputKey('comment'), {
+          v-decorator="[ formFieldName('comment'), {
             rules: [],
           }]"/>
       </a-form-item>
@@ -89,6 +89,7 @@
 <script lang="ts">
 import Vue from 'vue'
 import mixins from 'vue-typed-mixins'
+import * as typing from '@/util/typing'
 import Api from '@/api'
 import moment from 'moment'
 
@@ -108,7 +109,7 @@ export default mixins(FormGroupMixin).extend({
     DateInput,
     PatientInput,
   },
-  inputKeys: ['id', 'source', 'contact', 'dateOfContact', 'context', 'comment'],
+  fieldIdentifiers: ['id', 'source', 'contact', 'dateOfContact', 'context', 'comment'],
   props: {
     showOriginatorPatient: { default: true },
     showContactPatient: { default: true },
@@ -121,15 +122,18 @@ export default mixins(FormGroupMixin).extend({
     }
   },
   methods: {
+    withExts() {
+      return typing.extended(this, typing.TypeArg<FormGroupMixin>())
+    },
     moment,
     filterContacts(inputVal: string, option: any): boolean {
-      return option.key !== (this as any).getSingleValue('source')
+      return option.key !== this.withExts().getSingleValue('source')
     },
     filterSources(inputVal: string, option: any): boolean {
-      return option.key !== (this as any).getSingleValue('contact')
+      return option.key !== this.withExts().getSingleValue('contact')
     },
   },
-} as any)
+})
 </script>
 
 <style lang="scss">

--- a/client/src/components/PatientStammdaten.vue
+++ b/client/src/components/PatientStammdaten.vue
@@ -107,11 +107,9 @@
         <a-divider />
         <p style="text-align: center">Aufenthaltsort, falls von Wohnort abweichend:</p>
         <location-form-group
-          :form="form"
           :data="patient"
           :required="false"
-          inputKeyPrefix="stay"
-          :useInputKeysForData="true"/>
+          fieldNamePrefix="stay"/>
       </div>
 
       <!-- Email / Telefon -->

--- a/client/src/util/forms.ts
+++ b/client/src/util/forms.ts
@@ -1,4 +1,12 @@
-import Vue from 'vue'
+/**
+ * Module providing utility mixins for creating wrapper controls or form
+ * control groups operating with AntDV forms.
+ */
+
+import Vue, { PropType } from 'vue'
+import * as typing from '@/util/typing'
+
+// >>>>> HELPER FUNCTION & DECLARATION SECTION >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 // Realise camelCase prefixing, whereas the prefixed name starts with capital
 function prefixed(name: string, prefix?: string): string {
@@ -8,67 +16,144 @@ function prefixed(name: string, prefix?: string): string {
     return prefix + name.charAt(0).toUpperCase() + name.substring(1)
   }
 }
-function prefixedKeysObject(keys: {[x: string]: any}, prefix?: string): {[x: string]: any} {
-  return Object.fromEntries((Object.entries(keys) as [string, string][]).map(
-    (entry: [string, string]) => [prefixed(entry[0], prefix), entry[1]],
-  ))
-}
-function prefixedKeysArray(keys: string[], prefix?: string): string[] {
-  return keys.map((key: string) => prefixed(key, prefix))
-}
 
-declare interface FormGroupMixinType {
-  $options: {
-    name: string;
-    inputKeys: string[];
+interface MinimalFormContext {
+  form: {
+    formItems: Record<string, {
+      itemSelfUpdate: boolean;
+    }>;
+    setFieldsValue(vals: Record<string, any>): void;
+    getFieldsValue(names?: string[]): Record<string, any>;
   };
-  $props: {
-    inputKeyPrefix?: string;
-    inputKeys: { [x: string]: string };
-    inputProps: Record<string, any>;
-  };
-  $watch: any;
-  $forceUpdate: () => void;
-
-  formInputKey: (this: FormGroupMixinType, key: string) => string;
-  FormContext: any;
-
-  prefixedKeysObject: (this: FormGroupMixinType, keys: {[x: string]: any}, prefix?: string) => {[x: string]: any};
-  prefixedKeysArray: (this: FormGroupMixinType, keys: string[], prefix?: string) => string[];
-  getData(this: FormGroupMixinType, fieldNames?: string[], usesPrefixedKeys?: boolean): {[x: string]: any};
 }
+
+// >>>>> MIXIN DEFINITIONS >>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {
-    inputKeys?: string[];
+    fieldIdentifiers?: string[];
   }
 }
 
+export interface FormGroupMixin {
+  $options: {
+    /**
+     * Array of all the field identifiers used for the fields managed by
+     * this form group component.
+     */
+    fieldIdentifiers?: string[];
+  };
+
+  $props: {
+    /**
+     * Optional prefix to be applied to all field names.
+     */
+    fieldNamePrefix?: string;
+    /**
+     * Optional mapping of field identifiers to custom field names for some
+     * or all fields. The names of fields not specified in this map are subject
+     * to default field naming, respecting a provided field name prefix.
+     */
+    fieldNames?: Record<string, string>;
+    /**
+     * Optional props to apply to some or all fields. The top level key
+     * is the identifier of the form field with a map of the props to apply
+     * to that field as the respective value.
+     */
+    controlProps?: Record<string, Record<string, any>>;
+  };
+
+  /**
+   * Generates the name to be used for the field with the given identifier,
+   * according to field name overrides (see inputKeys prop) and field name
+   * prefixing (see inputKeyPrefix prop). This function is typically called
+   * to generate the appropriate field name for the v-decorator directive.
+   */
+  formFieldName(fieldId: string): string;
+
+  /**
+   * Sets some or all fields of this form group. The second parameter specifies
+   * whether the passed key-value mapping's keys specify field identifiers or
+   * the actual field names as used in the form.
+   */
+  setData(data: Record<string, any>, usesFormFieldNames?: boolean): void;
+  /**
+   * Retrieves the values of some or all fields of this form group. The optional
+   * second parameter specifies whether the given field name array specifies
+   * field identifiers or the actual field names as used in the form. The result
+   * mapping will map the values by the same names.
+   */
+  getData(fieldNames?: string[], usesFormFieldNames?: boolean): Record<string, any>;
+  /**
+   * Retrieves the value of one specific field of this form group. The optional
+   * second parameter specifies whether the given field name array specifies
+   * field identifiers or the actual field names as used in the form.
+   */
+  getSingleValue(fieldName: string, usesFormFieldNames?: boolean): any | undefined;
+}
+
+/**
+ * Mixin providing utility functionality like prefixing and re-mapping field
+ * names and accessing field values for form group components.
+ *
+ * For using this mixin effectively, you have to
+ *
+ *  - specify field identifiers for all the fields that shall be managed by the
+ *    implementing form group by defining the `fieldIdentifiers` option with an
+ *    array of those names. Field identifiers are quite similar to form field
+ *    names, but may not be unique across the whole form. Therefore, field
+ *    identifiers are only valid within an instance of the form group where
+ *    they can be used to access the managed fields' values.
+ *
+ *  - use the `formFieldName` function in field decorator definitions that will
+ *    translate the given assigned field identifier into the field's name within
+ *    the form. By doing so, components using the form group can adapt the names
+ *    of the form group instance's fields as required by external conditions and
+ *    uniqueness across the form.
+ *
+ * See type interface for information about exposed API.
+ */
 export const FormGroupMixin = Vue.extend({
   props: {
-    inputKeyPrefix: {
+    fieldNamePrefix: {
+      type: String as PropType<string>,
       default: undefined,
     },
-    inputKeys: {
+    fieldIdentifiers: {
+      type: Object as PropType<Record<string, string>>,
       default: () => ({}),
     },
     inputProps: {
-      default(this: FormGroupMixinType) {
+      type: Object as PropType<Record<string, Record<string, any>>>,
+      default(): Record<string, Record<string, any>> {
         return Object.fromEntries(
-          this.$options.inputKeys!.map((key: string) => [key, {}]),
+          this.$options.fieldIdentifiers!.map((key: string) => [key, {}]),
         )
       },
     },
   },
+  data() {
+    return {
+      formFieldNameBackTranslation: {} as Record<string, string>,
+    }
+  },
   inject: {
     FormContext: { default: () => ({}) },
   },
-  mounted(this: FormGroupMixinType) {
-    if (this.$options.inputKeys) {
+  created() {
+    if (this.$options.fieldIdentifiers) {
+      this.$options.fieldIdentifiers.forEach((fieldId: string) => {
+        this.formFieldNameBackTranslation[this.formFieldName(fieldId)] = fieldId
+      })
+    }
+  },
+  mounted(): void {
+    if (this.$options.fieldIdentifiers) {
       // Make sure all form items use selfUpdate; this is crucial for form items
       // in the group to be re-rendered correctly when new values are set
-      this.$options.inputKeys.forEach((key: string) => {
-        if (!this.FormContext.form.formItems[this.formInputKey(key)].itemSelfUpdate) {
+      this.$options.fieldIdentifiers.forEach((key: string) => {
+        if (this.getFormContext().form.formItems[
+          this.formFieldName(key)].itemSelfUpdate) {
           console.error(`[ ${this.$options.name} ]: ` +
             `\`itemSelfUpdate\` is not enabled for form item of \`${key}\`. ` +
             'This may lead to contents not being re-rendered when their ' +
@@ -82,90 +167,81 @@ export const FormGroupMixin = Vue.extend({
     }
   },
   methods: {
-    formInputKey(this: FormGroupMixinType, key: string): string {
-      const propKeys = this.$props.inputKeys
-      return Object.prototype.hasOwnProperty.call(propKeys, key)
+    getFormContext() {
+      return typing.extended(this, typing.TypeArg<{
+        FormContext: MinimalFormContext;
+      }>()).FormContext
+    },
+    formFieldName(key: string): string {
+      const propKeys = this.$props.fieldNames
+      return propKeys && Object.prototype.hasOwnProperty.call(propKeys, key)
         ? propKeys[key]
-        : prefixed(key, this.$props.inputKeyPrefix)
+        : prefixed(key, this.$props.fieldNamePrefix)
     },
-    prefixedKeysObject(this: FormGroupMixinType, keys: {[x: string]: any}): {[x: string]: any} {
-      return prefixedKeysObject(keys, this.$props.inputKeyPrefix)
-    },
-    prefixedKeysArray(this: FormGroupMixinType, keys: string[]): string[] {
-      return prefixedKeysArray(keys, this.$props.inputKeyPrefix)
-    },
-    setData(this: FormGroupMixinType, data: {[x: string]: any}, usesPrefixedKeys: boolean | undefined) {
-      if (!this.$options.inputKeys) {
+    setData(data: Record<string, any>, usesFormFieldNames?: boolean) {
+      if (!this.$options.fieldIdentifiers) {
         throw new Error(`[ ${this.$options.name} ]: \`setData\` not supported`)
       }
 
-      if (!usesPrefixedKeys) {
-        data = this.prefixedKeysObject(data)
-      }
-      if (data) {
-        const prefixedInputKeys = prefixedKeysArray(this.$options.inputKeys)
-        data = Object.fromEntries(Object.entries(data).filter(
-          (value: [string, any]) => prefixedInputKeys.includes(value[0]),
+      // Check if conversion of identifiers to field names is required
+      if (!usesFormFieldNames) {
+        data = Object.fromEntries(Object.entries(data).map(
+          (entry: [string, any]) => [this.formFieldName(entry[0]), entry[1]],
         ))
       }
-      this.FormContext.form.setFieldsValue(data)
+
+      // Filter out any names that do not have a corresponding identifier
+      // defined using the fieldIdentifiers option
+      const fieldNames = this.$options.fieldIdentifiers.map(this.formFieldName)
+      data = Object.fromEntries(Object.entries(data).filter(
+        (value: [string, any]) => fieldNames.includes(value[0]),
+      ))
+
+      // Set the values
+      this.getFormContext().form.setFieldsValue(data)
     },
-    getData(this: FormGroupMixinType, fieldNames?: string[], usesPrefixedKeys?: boolean): {[x: string]: any} {
-      if (!this.$options.inputKeys) {
+    getData(fieldNames?: string[], usesFormFieldNames?: boolean): Record<string, any> {
+      if (!this.$options.fieldIdentifiers) {
         throw new Error(`[ ${this.$options.name} ]: \`getData\` not supported`)
       }
 
-      if (fieldNames !== undefined && !usesPrefixedKeys) {
-        fieldNames = this.prefixedKeysArray(fieldNames)
+      if (fieldNames !== undefined && !usesFormFieldNames) {
+        // fieldNames contains field identifiers that need to be translated
+        fieldNames = fieldNames.map((fieldId: string) => {
+          const formFieldName = this.formFieldName(fieldId)
+          return formFieldName
+        })
       }
 
-      const permittedFieldNames = prefixedKeysArray(this.$options.inputKeys)
+      const permittedFieldNames = this.$options.fieldIdentifiers.map(this.formFieldName)
       if (fieldNames === undefined) {
+        // No specific field names specified is equivalent to getting them all
         fieldNames = permittedFieldNames
       } else {
+        // Filter out any names that do not have a corresponding identifier
+        // defined using the fieldIdentifiers option
         fieldNames = fieldNames.filter(
           (fieldName: string) => permittedFieldNames.includes(fieldName),
         )
       }
-      return this.FormContext.form.getFieldsValue(fieldNames)
+
+      // Retrieve the requested values; if field names have been specified
+      // as field identifiers, the result's keys will be translated back
+      let result = this.getFormContext().form.getFieldsValue(fieldNames)
+      if (!usesFormFieldNames) {
+        result = Object.fromEntries(Object.entries(result).map((entry: [string, any]) =>
+          [this.formFieldNameBackTranslation[entry[0]], entry[1]],
+        ))
+      }
+
+      return result
     },
-    getSingleValue(this: FormGroupMixinType, fieldName: string, usesPrefixedKeys?: boolean): any | undefined {
-      const key = usesPrefixedKeys ? fieldName : this.formInputKey(fieldName)
+    getSingleValue(fieldName: string, usesFormFieldNames?: boolean): any | undefined {
+      const key = usesFormFieldNames ? fieldName : this.formFieldName(fieldName)
       return this.getData([key], true)[key]
     },
   },
 })
-
-declare interface FormControlMixinType {
-  $options: {
-    fieldValueConvert?: (val: any) => any;
-    forwardEvents?: string[];
-    model?: {
-      prop?: string;
-      event?: string;
-    };
-  };
-  $attrs: {
-    'data-__field'?: {
-      name: string;
-      value: any;
-    };
-  };
-  $emit: (event: string, param?: any) => void;
-  $watch: (expr: string, cb: (val: any) => void) => void;
-
-  FormContext?: {
-    form: {
-      setFieldsValue: (fields: { [x: string]: any }) => void;
-    };
-  };
-
-  FormControlConvValue: any;
-  fieldName: string | null;
-  isDecoratedFormField(): boolean;
-  getOwnValue(): any;
-  setOwnValue(val: any): void;
-}
 
 declare module 'vue/types/options' {
   interface ComponentOptions<V extends Vue> {
@@ -173,14 +249,56 @@ declare module 'vue/types/options' {
   }
 }
 
+export interface FormControlMixin {
+  $options: {
+    /**
+     * Optional function for converting values into this control's native value
+     * format. It will be automatically called whenever some value is applied
+     * to this control, e.g. by a `setFieldsValue` on the supporting form. It is
+     * therefore well-suited for wrapper controls that want to support additional
+     * value types to the ones allowed by the wrapped control.
+     *
+     * The implementor of this function has to ensure that this function behaves
+     * like the identity function for the native value format, since failure to do
+     * so may lead to infinite recursion.
+     */
+    fieldValueConvert?(value: any): any;
+  };
+
+  /**
+   * The name of this form control as specified by field decorator.
+   */
+  fieldName: string | null;
+
+  /**
+   * Returns whether this form control is used in conjunction with a field decorator.
+   */
+  isDecoratedFormField(): boolean;
+
+  /**
+   * Sets the value of this control.
+   */
+  setOwnValue(value: any): void;
+  /**
+   * Retrieves the current value of this control.
+   */
+  getOwnValue(): any;
+}
+
+/**
+ * Mixin providing utility functionality to form controls or AntDV form control
+ * wrappers.
+ *
+ * See type interface for information about the exposed API.
+ */
 export const FormControlMixin = Vue.extend({
   inject: {
-    FormContext: { default: null },
+    FormContext: { default: () => ({}) },
   },
   computed: {
-    fieldName(this: FormControlMixinType): string | null {
-      if (this.FormContext && this.$attrs['data-__field']) {
-        return this.$attrs['data-__field'].name
+    fieldName(): string | null {
+      if (this.getFormContext() && this.$attrs['data-__field']) {
+        return (typing.cast<{ name: string }>(this.$attrs['data-__field'])).name
       } else {
         return null
       }
@@ -191,7 +309,7 @@ export const FormControlMixin = Vue.extend({
       FormControlConvValue: undefined,
     }
   },
-  created(this: FormControlMixinType) {
+  created() {
     if (this.$options.fieldValueConvert) {
       const valueProp = (this.$options.model && this.$options.model.prop)
         ? this.$options.model.prop
@@ -212,21 +330,26 @@ export const FormControlMixin = Vue.extend({
     }
   },
   methods: {
-    isDecoratedFormField(this: FormControlMixinType): boolean {
-      return !!(this.FormContext && this.$attrs['data-__field'])
+    getFormContext(): MinimalFormContext {
+      return typing.extended(this, typing.TypeArg<{
+        FormContext: MinimalFormContext;
+      }>()).FormContext
     },
-    setOwnValue(this: FormControlMixinType, value: any) {
+    isDecoratedFormField(): boolean {
+      return !!(this.getFormContext() && this.$attrs['data-__field'])
+    },
+    setOwnValue(value: any) {
       const eventType = (this.$options.model && this.$options.model.event)
         ? this.$options.model.event
         : 'change'
 
       this.$emit(eventType, value)
     },
-    getOwnValue(this: FormControlMixinType) {
+    getOwnValue() {
       const valueProp = (this.$options.model && this.$options.model.prop)
         ? this.$options.model.prop
         : 'value'
-      return (this as {[x: string]: any})[valueProp]
+      return (this as Record<string, any>)[valueProp]
     },
   },
 })

--- a/client/src/util/typing.ts
+++ b/client/src/util/typing.ts
@@ -1,0 +1,35 @@
+/**
+ * Typescript utility module.
+ */
+
+/// Type representing a Type parameter to be passed to a type-inferring function.
+export type TypeArg<T> = T;
+
+/**
+ * TypeArg generator. This function may be called for any TypeArg function
+ * argument to provide a type for type inferrence.
+ *
+ * Note that this function's sole purpose is type inferrence and no actual
+ * object is created.
+ */
+export function TypeArg<T>(): TypeArg<T> {
+  return null as unknown as TypeArg<T>
+}
+
+/**
+ * Simple cast avoiding explicit conversion to unknown.
+ */
+export function cast<T>(arg: unknown, _?: TypeArg<T>) { return arg as T }
+
+/**
+ * Identity function telling the Typescript compiler that the supplied argument
+ * is additionally supporting data and operations from the given extension type.
+ * This function may be used in contexts where current type inferrence mechanisms
+ * fail at resolving all of the functionality a type is actually capable of.
+ *
+ * An example use case is the use of mixins or injections for Vue components,
+ * which currently cannot be sufficiently inferred.
+ */
+export function extended<T, ExtensionType>(obj: T, _: TypeArg<ExtensionType>): (T & ExtensionType) {
+  return obj as (T & ExtensionType)
+}


### PR DESCRIPTION
This pull request

- introduces documentation of the `forms.ts` module
- changes some property and option names of the form utility mixins for further clarity
- removes some bloatcode formerly introduced for pleasing the Typescript linter
- introduces `typing.ts` module, providing functionality to cope with the resulting Typescript inference problems
- adapts `LocationFormGroup` component to use `FormGroupMixin`