### PR TITLE
Fix missing person test data

### DIFF
--- a/server/src/main/resources/sample_data/genPersons.py
+++ b/server/src/main/resources/sample_data/genPersons.py
@@ -116,11 +116,11 @@ def gen_person():
 		'email': email,
 		'phoneNumber': rand_num_str(),
 # include house number within street field
-		'street': {choice(streets)} {randint(0, 100)},
+		'street': '{} {}'.format(choice(streets), randint(0, 100)),
 #		'houseNumber': randint(0, 100),
 # temporarily filter zip codes to saarland region (approximately)
 #		'zip': rand_num_str(5),
-		'zip': {'66'}{rand_num_str(3)},
+		'zip': '66{}'.format(rand_num_str(3)),
 		'city': choice(cities),
 		'insuranceCompany': choice(insurance_companies),
 		'insuranceMembershipNumber': insurance_number(),
@@ -136,9 +136,14 @@ def gen_person():
 
 
 def main():
+	import sys
 	pathlib.Path('persons').mkdir(parents=True, exist_ok=True)
 
-	for i in range(100):
+	amount = 250  # default
+	if len(sys.argv) >= 1:
+		amount = int(sys.argv[1])
+
+	for i in range(amount):
 		with open(f'persons/person{i}.json', 'w+') as f:
 			f.write(json.dumps(gen_person(), sort_keys=True, indent=2))
 

--- a/server/src/main/resources/sample_data/persons/person0.json
+++ b/server/src/main/resources/sample_data/persons/person0.json
@@ -1,26 +1,29 @@
 {
-  "city": "Frankfurt",
+  "city": "St. Ingbert",
   "coronaContacts": true,
-  "dateOfBirth": "1974-04-05",
-  "email": "p.winkler@gmail.de",
+  "dateOfBirth": "1977-03-24",
+  "email": "p.bauer@posteo.de",
   "firstName": "Peter",
   "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 64,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "H582334538",
-  "lastName": "Winkler",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "U853041955",
+  "lastName": "Bauer",
   "nationality": "deutsch",
   "phoneNumber": "11081960013",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "GrandEst"
+    "Moscow"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Schernerweg",
-  "symptoms": [],
-  "weakenedImmuneSystem": true,
-  "zip": "908310"
+  "street": "Abbendiekshof 64",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66908"
 }

--- a/server/src/main/resources/sample_data/persons/person1.json
+++ b/server/src/main/resources/sample_data/persons/person1.json
@@ -1,31 +1,27 @@
 {
-  "city": "K\u00f6ln",
-  "coronaContacts": false,
-  "dateOfBirth": "1962-02-03",
-  "email": "p.schulz@posteo.de",
-  "firstName": "Petra",
-  "fluImmunization": true,
+  "city": "Heusweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1978-06-04",
+  "email": "m.bauer@posteo.de",
+  "firstName": "Marie",
+  "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 10,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "C149203558",
-  "lastName": "Schulz",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "L719927151",
+  "lastName": "Bauer",
   "nationality": "deutsch",
-  "phoneNumber": "6155940781",
+  "phoneNumber": "1615594078",
   "preIllnesses": [
     "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Hubei"
+    "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Niekampsweg",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Schernerweg 48",
   "symptoms": [
-    "Fieber",
-    "Halschmerzen",
-    "Gelenkschmerzen",
     "Husten"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "841095"
+  "weakenedImmuneSystem": true,
+  "zip": "66184"
 }

--- a/server/src/main/resources/sample_data/persons/person10.json
+++ b/server/src/main/resources/sample_data/persons/person10.json
@@ -1,33 +1,34 @@
 {
-  "city": "D\u00fcsseldorf",
+  "city": "Homburg",
   "coronaContacts": true,
-  "dateOfBirth": "1979-12-11",
-  "email": "k.weber@web.de",
-  "firstName": "Karl",
+  "dateOfBirth": "2004-08-20",
+  "email": "d.lange@t-online.de",
+  "firstName": "Daniela",
   "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 35,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "X574417266",
-  "lastName": "Weber",
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "J756783995",
+  "lastName": "Lange",
   "nationality": "deutsch",
-  "phoneNumber": "3101048740110",
+  "phoneNumber": "9118384251",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Madrid"
+    ""
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Niekampsweg",
+  "street": "Abbendiekshof 47",
   "symptoms": [
     "Husten",
-    "Gelenkschmerzen",
-    "Halschmerzen",
-    "Fieber",
     "Kopfschmerzen",
-    "Atemschwierigkeiten"
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Fieber",
+    "Halschmerzen"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "005210"
+  "weakenedImmuneSystem": true,
+  "zip": "66427"
 }

--- a/server/src/main/resources/sample_data/persons/person100.json
+++ b/server/src/main/resources/sample_data/persons/person100.json
@@ -1,0 +1,27 @@
+{
+  "city": "Bous",
+  "coronaContacts": true,
+  "dateOfBirth": "1951-12-13",
+  "email": "e.berger@gmx.de",
+  "firstName": "Emma",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "U919505668",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "11088924141",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Hafenstra\u00dfe 26",
+  "symptoms": [
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66285"
+}

--- a/server/src/main/resources/sample_data/persons/person101.json
+++ b/server/src/main/resources/sample_data/persons/person101.json
@@ -1,0 +1,30 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1991-08-20",
+  "email": "f.schulz@gmx.de",
+  "firstName": "Franz",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "I279275105",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "904101021020",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Abbachstra\u00dfe 63",
+  "symptoms": [
+    "Fieber",
+    "Halschmerzen",
+    "Husten",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66588"
+}

--- a/server/src/main/resources/sample_data/persons/person102.json
+++ b/server/src/main/resources/sample_data/persons/person102.json
@@ -1,0 +1,32 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1947-09-12",
+  "email": "h.schulz@gmx.de",
+  "firstName": "Hanna",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "H149372289",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "07925241910",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Tulpenweg 14",
+  "symptoms": [
+    "Schnupfen",
+    "Fieber",
+    "Husten",
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66380"
+}

--- a/server/src/main/resources/sample_data/persons/person103.json
+++ b/server/src/main/resources/sample_data/persons/person103.json
@@ -1,0 +1,30 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": true,
+  "dateOfBirth": "1958-02-17",
+  "email": "i.schulz@web.de",
+  "firstName": "Isabella",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "L315469014",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "10023806174",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "B\u00fcckerheide 39",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66518"
+}

--- a/server/src/main/resources/sample_data/persons/person104.json
+++ b/server/src/main/resources/sample_data/persons/person104.json
@@ -1,0 +1,34 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "2002-04-18",
+  "email": "h.peters@gmx.de",
+  "firstName": "Hans",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "I199886596",
+  "lastName": "Peters",
+  "nationality": "deutsch",
+  "phoneNumber": "510050106413",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hafenstra\u00dfe 30",
+  "symptoms": [
+    "Halschmerzen",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Erk\u00e4ltung",
+    "Husten",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66670"
+}

--- a/server/src/main/resources/sample_data/persons/person105.json
+++ b/server/src/main/resources/sample_data/persons/person105.json
@@ -1,0 +1,27 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1968-05-28",
+  "email": "j.weber@posteo.de",
+  "firstName": "Jan",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "O600422869",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "5655743132",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "B\u00fcckerheide 98",
+  "symptoms": [
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66912"
+}

--- a/server/src/main/resources/sample_data/persons/person106.json
+++ b/server/src/main/resources/sample_data/persons/person106.json
@@ -1,0 +1,34 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": true,
+  "dateOfBirth": "1994-03-26",
+  "email": "d.bauer@t-online.de",
+  "firstName": "Daniela",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "A534212844",
+  "lastName": "Bauer",
+  "nationality": "deutsch",
+  "phoneNumber": "10490352135",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Z\u00e4hringerstra\u00dfe 65",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Husten",
+    "Gelenkschmerzen",
+    "Halschmerzen",
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "660104"
+}

--- a/server/src/main/resources/sample_data/persons/person107.json
+++ b/server/src/main/resources/sample_data/persons/person107.json
@@ -1,0 +1,32 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1925-11-03",
+  "email": "f.winter@gmail.de",
+  "firstName": "Franz",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "S565098113",
+  "lastName": "Winter",
+  "nationality": "deutsch",
+  "phoneNumber": "99410131072",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Haidth\u00f6heAarweg 42",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Husten",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Fieber",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66107"
+}

--- a/server/src/main/resources/sample_data/persons/person108.json
+++ b/server/src/main/resources/sample_data/persons/person108.json
@@ -1,0 +1,32 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": true,
+  "dateOfBirth": "1926-10-08",
+  "email": "a.mueller@web.de",
+  "firstName": "Anna",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "Z683746914",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "10476870146",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Aastwiete 53",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Halschmerzen",
+    "Schnupfen",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "663108"
+}

--- a/server/src/main/resources/sample_data/persons/person109.json
+++ b/server/src/main/resources/sample_data/persons/person109.json
@@ -1,0 +1,28 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1977-01-29",
+  "email": "p.lange@web.de",
+  "firstName": "Peter",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "S956191734",
+  "lastName": "Lange",
+  "nationality": "deutsch",
+  "phoneNumber": "4078593213",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Bismarckstra\u00dfe 30",
+  "symptoms": [
+    "Schnupfen",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66480"
+}

--- a/server/src/main/resources/sample_data/persons/person11.json
+++ b/server/src/main/resources/sample_data/persons/person11.json
@@ -1,33 +1,34 @@
 {
-  "city": "K\u00f6ln",
+  "city": "Dudweiler",
   "coronaContacts": false,
-  "dateOfBirth": "2000-06-07",
-  "email": "p.weber@gmail.de",
-  "firstName": "Peter",
+  "dateOfBirth": "1979-11-21",
+  "email": "p.richter@gmail.de",
+  "firstName": "Petra",
   "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 22,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "F945436943",
-  "lastName": "Weber",
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "O692362342",
+  "lastName": "Richter",
   "nationality": "deutsch",
-  "phoneNumber": "103101586923",
+  "phoneNumber": "48740110640",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Hubei"
+    ""
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Haidth\u00f6heAarweg",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Aarhusweg 42",
   "symptoms": [
     "Husten",
+    "Gelenkschmerzen",
     "Halschmerzen",
-    "Erk\u00e4ltung",
     "Fieber",
+    "Kopfschmerzen",
     "Atemschwierigkeiten",
-    "Kopfschmerzen"
+    "Erk\u00e4ltung",
+    "Schnupfen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "60256"
+  "weakenedImmuneSystem": false,
+  "zip": "662104"
 }

--- a/server/src/main/resources/sample_data/persons/person110.json
+++ b/server/src/main/resources/sample_data/persons/person110.json
@@ -1,0 +1,31 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1933-03-19",
+  "email": "m.winkler@web.de",
+  "firstName": "Matthias",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "T316320731",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "3784270103",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Eisenbahnstra\u00dfe 28",
+  "symptoms": [
+    "Schnupfen",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Husten",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66087"
+}

--- a/server/src/main/resources/sample_data/persons/person111.json
+++ b/server/src/main/resources/sample_data/persons/person111.json
@@ -1,0 +1,31 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1996-06-23",
+  "email": "c.berger@gmail.de",
+  "firstName": "Cornelius",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "R844704803",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "10691545226",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordstra\u00dfe 81",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "667105"
+}

--- a/server/src/main/resources/sample_data/persons/person112.json
+++ b/server/src/main/resources/sample_data/persons/person112.json
@@ -1,0 +1,31 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1955-10-02",
+  "email": "h.peters@web.de",
+  "firstName": "Hans",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "U195268824",
+  "lastName": "Peters",
+  "nationality": "deutsch",
+  "phoneNumber": "29593109172",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "S\u00fcdweg 95",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Husten",
+    "Schnupfen",
+    "Fieber",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66135"
+}

--- a/server/src/main/resources/sample_data/persons/person113.json
+++ b/server/src/main/resources/sample_data/persons/person113.json
@@ -1,0 +1,30 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1956-08-24",
+  "email": "m.peters@t-online.de",
+  "firstName": "Matthias",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "C958128631",
+  "lastName": "Peters",
+  "nationality": "deutsch",
+  "phoneNumber": "6267658617",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Nordstra\u00dfe 73",
+  "symptoms": [
+    "Husten",
+    "Schnupfen",
+    "Halschmerzen",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "6610103"
+}

--- a/server/src/main/resources/sample_data/persons/person114.json
+++ b/server/src/main/resources/sample_data/persons/person114.json
@@ -1,0 +1,30 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": false,
+  "dateOfBirth": "1994-06-20",
+  "email": "m.schulz@web.de",
+  "firstName": "Matthias",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "X883803621",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "97061029620",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Schernerweg 42",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Husten",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66336"
+}

--- a/server/src/main/resources/sample_data/persons/person115.json
+++ b/server/src/main/resources/sample_data/persons/person115.json
@@ -1,0 +1,30 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1951-02-10",
+  "email": "p.winkler@t-online.de",
+  "firstName": "Peter",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "P625163699",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "1010973103210",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Wintergasse 10",
+  "symptoms": [
+    "Fieber",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66714"
+}

--- a/server/src/main/resources/sample_data/persons/person116.json
+++ b/server/src/main/resources/sample_data/persons/person116.json
@@ -1,0 +1,34 @@
+{
+  "city": "Homburg",
+  "coronaContacts": true,
+  "dateOfBirth": "1972-08-15",
+  "email": "a.schmitt@t-online.de",
+  "firstName": "Anna",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "M978755907",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "434902101110",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Hauptstra\u00dfe 69",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Erk\u00e4ltung",
+    "Schnupfen",
+    "Husten",
+    "Kopfschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66693"
+}

--- a/server/src/main/resources/sample_data/persons/person117.json
+++ b/server/src/main/resources/sample_data/persons/person117.json
@@ -1,0 +1,30 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1984-04-26",
+  "email": "c.schmitt@posteo.de",
+  "firstName": "Christopher",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "R526656677",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "320611063102",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Nordtstra\u00dfe 76",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Halschmerzen",
+    "Husten",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66451"
+}

--- a/server/src/main/resources/sample_data/persons/person118.json
+++ b/server/src/main/resources/sample_data/persons/person118.json
@@ -1,0 +1,32 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1933-10-19",
+  "email": "j.weber@posteo.de",
+  "firstName": "Jan",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "I532689999",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "1191485646",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Kronenstra\u00dfe 62",
+  "symptoms": [
+    "Husten",
+    "Erk\u00e4ltung",
+    "Schnupfen",
+    "Fieber",
+    "Gelenkschmerzen",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66997"
+}

--- a/server/src/main/resources/sample_data/persons/person119.json
+++ b/server/src/main/resources/sample_data/persons/person119.json
@@ -1,0 +1,25 @@
+{
+  "city": "Bous",
+  "coronaContacts": true,
+  "dateOfBirth": "1970-08-28",
+  "email": "t.schroeder@gmail.de",
+  "firstName": "Tim",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "P915499713",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "10132475469",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Kronenstra\u00dfe 11",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "66373"
+}

--- a/server/src/main/resources/sample_data/persons/person12.json
+++ b/server/src/main/resources/sample_data/persons/person12.json
@@ -1,35 +1,27 @@
 {
-  "city": "Freiburg",
+  "city": "Riegelsberg",
   "coronaContacts": true,
-  "dateOfBirth": "1954-06-09",
-  "email": "p.lange@posteo.de",
-  "firstName": "Peter",
-  "fluImmunization": false,
+  "dateOfBirth": "1974-11-04",
+  "email": "k.winkler@posteo.de",
+  "firstName": "Konrad",
+  "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 33,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "X944420824",
-  "lastName": "Lange",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "I270937380",
+  "lastName": "Winkler",
   "nationality": "deutsch",
-  "phoneNumber": "145108610850",
+  "phoneNumber": "5869232260",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Madrid"
+    ""
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Im KramersfeldAar\u00f6stra\u00dfe",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Abbachstra\u00dfe 94",
   "symptoms": [
-    "Fieber",
-    "Erk\u00e4ltung",
-    "Atemschwierigkeiten",
-    "Gelenkschmerzen",
-    "Schnupfen",
-    "Husten",
-    "Kopfschmerzen",
     "Halschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "29401"
+  "zip": "665610"
 }

--- a/server/src/main/resources/sample_data/persons/person120.json
+++ b/server/src/main/resources/sample_data/persons/person120.json
@@ -1,0 +1,25 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": false,
+  "dateOfBirth": "1988-09-29",
+  "email": "h.berger@gmx.de",
+  "firstName": "Hanna",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "M782266083",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "9023303070",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hauptstra\u00dfe 90",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "66345"
+}

--- a/server/src/main/resources/sample_data/persons/person121.json
+++ b/server/src/main/resources/sample_data/persons/person121.json
@@ -1,0 +1,25 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": false,
+  "dateOfBirth": "1935-06-12",
+  "email": "c.schmidt@web.de",
+  "firstName": "Cornelius",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "U539705006",
+  "lastName": "Schmidt",
+  "nationality": "deutsch",
+  "phoneNumber": "2414060293",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Nordufer 28",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "6610310"
+}

--- a/server/src/main/resources/sample_data/persons/person122.json
+++ b/server/src/main/resources/sample_data/persons/person122.json
@@ -1,0 +1,34 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1966-12-31",
+  "email": "f.bauer@web.de",
+  "firstName": "Franz",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "Q811198748",
+  "lastName": "Bauer",
+  "nationality": "deutsch",
+  "phoneNumber": "10466574374",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Bismarckstra\u00dfe 66",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Kopfschmerzen",
+    "Husten",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Fieber",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66969"
+}

--- a/server/src/main/resources/sample_data/persons/person123.json
+++ b/server/src/main/resources/sample_data/persons/person123.json
@@ -1,0 +1,29 @@
+{
+  "city": "Bous",
+  "coronaContacts": false,
+  "dateOfBirth": "1986-09-25",
+  "email": "e.schroeder@posteo.de",
+  "firstName": "Emma",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "B726016935",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "3096105102010",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Steinstra\u00dfe 37",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Gelenkschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66466"
+}

--- a/server/src/main/resources/sample_data/persons/person124.json
+++ b/server/src/main/resources/sample_data/persons/person124.json
@@ -1,0 +1,33 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1934-03-10",
+  "email": "p.schroeder@posteo.de",
+  "firstName": "Petra",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "L379773344",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "172482105101",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Abbendiekshof 45",
+  "symptoms": [
+    "Fieber",
+    "Erk\u00e4ltung",
+    "Husten",
+    "Atemschwierigkeiten",
+    "Kopfschmerzen",
+    "Gelenkschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66346"
+}

--- a/server/src/main/resources/sample_data/persons/person125.json
+++ b/server/src/main/resources/sample_data/persons/person125.json
@@ -1,0 +1,28 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": true,
+  "dateOfBirth": "1988-04-11",
+  "email": "s.mueller@posteo.de",
+  "firstName": "Susanne",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "G917325063",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "69725217510",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Abbachstra\u00dfe 40",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "661000"
+}

--- a/server/src/main/resources/sample_data/persons/person126.json
+++ b/server/src/main/resources/sample_data/persons/person126.json
@@ -1,0 +1,34 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": false,
+  "dateOfBirth": "1951-08-13",
+  "email": "e.sommer@gmx.de",
+  "firstName": "Emma",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "J238438399",
+  "lastName": "Sommer",
+  "nationality": "deutsch",
+  "phoneNumber": "0083505830",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Bismarckstra\u00dfe 0",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Husten",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Halschmerzen",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "661033"
+}

--- a/server/src/main/resources/sample_data/persons/person127.json
+++ b/server/src/main/resources/sample_data/persons/person127.json
@@ -1,0 +1,27 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": false,
+  "dateOfBirth": "1984-07-01",
+  "email": "d.winkler@posteo.de",
+  "firstName": "Daniela",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "T152169850",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "3323098215",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Rosenstra\u00dfe 83",
+  "symptoms": [
+    "Husten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "660610"
+}

--- a/server/src/main/resources/sample_data/persons/person128.json
+++ b/server/src/main/resources/sample_data/persons/person128.json
@@ -1,0 +1,30 @@
+{
+  "city": "Bous",
+  "coronaContacts": false,
+  "dateOfBirth": "1973-08-23",
+  "email": "s.schulze@web.de",
+  "firstName": "Susanne",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "Q871769353",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "23101004610110",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hafenstra\u00dfe 34",
+  "symptoms": [
+    "Fieber",
+    "Halschmerzen",
+    "Husten",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66992"
+}

--- a/server/src/main/resources/sample_data/persons/person129.json
+++ b/server/src/main/resources/sample_data/persons/person129.json
@@ -1,0 +1,30 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "1985-01-18",
+  "email": "t.sommer@gmail.de",
+  "firstName": "Tim",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "C876920515",
+  "lastName": "Sommer",
+  "nationality": "deutsch",
+  "phoneNumber": "73753001011",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Nordtstra\u00dfe 73",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "661072"
+}

--- a/server/src/main/resources/sample_data/persons/person13.json
+++ b/server/src/main/resources/sample_data/persons/person13.json
@@ -1,31 +1,25 @@
 {
-  "city": "D\u00fcsseldorf",
-  "coronaContacts": true,
-  "dateOfBirth": "1926-06-22",
-  "email": "s.mueller@gmail.de",
-  "firstName": "Susanne",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 24,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "R995205588",
-  "lastName": "M\u00fcller",
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1966-04-08",
+  "email": "f.schmitt@gmail.de",
+  "firstName": "Franz",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "I291735734",
+  "lastName": "Schmitt",
   "nationality": "deutsch",
-  "phoneNumber": "14841065648",
+  "phoneNumber": "010365414510",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Hubei"
+    "Madrid"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Haidth\u00f6heAarweg",
-  "symptoms": [
-    "Erk\u00e4ltung",
-    "Gelenkschmerzen",
-    "Atemschwierigkeiten",
-    "Kopfschmerzen"
-  ],
+  "street": "Hafenstra\u00dfe 51",
+  "symptoms": [],
   "weakenedImmuneSystem": false,
-  "zip": "6106102"
+  "zip": "661085"
 }

--- a/server/src/main/resources/sample_data/persons/person130.json
+++ b/server/src/main/resources/sample_data/persons/person130.json
@@ -1,0 +1,30 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1965-07-24",
+  "email": "c.schroeder@gmail.de",
+  "firstName": "Cornelius",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "D530331581",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "110021010255",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Waldstra\u00dfe 79",
+  "symptoms": [
+    "Halschmerzen",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66415"
+}

--- a/server/src/main/resources/sample_data/persons/person131.json
+++ b/server/src/main/resources/sample_data/persons/person131.json
@@ -1,0 +1,31 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1992-07-30",
+  "email": "m.mueller@posteo.de",
+  "firstName": "Matthias",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "O149362414",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "97910729659",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Aarhusweg 87",
+  "symptoms": [
+    "Husten",
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66277"
+}

--- a/server/src/main/resources/sample_data/persons/person132.json
+++ b/server/src/main/resources/sample_data/persons/person132.json
@@ -1,0 +1,25 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1961-11-22",
+  "email": "j.klein@gmx.de",
+  "firstName": "Jan",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "K358655621",
+  "lastName": "Klein",
+  "nationality": "deutsch",
+  "phoneNumber": "106289001028",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Nordufer 60",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "66721"
+}

--- a/server/src/main/resources/sample_data/persons/person133.json
+++ b/server/src/main/resources/sample_data/persons/person133.json
@@ -1,0 +1,30 @@
+{
+  "city": "Homburg",
+  "coronaContacts": true,
+  "dateOfBirth": "1947-08-26",
+  "email": "i.klein@t-online.de",
+  "firstName": "Isabella",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "C950170825",
+  "lastName": "Klein",
+  "nationality": "deutsch",
+  "phoneNumber": "97177517100",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Schernerweg 51",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66608"
+}

--- a/server/src/main/resources/sample_data/persons/person134.json
+++ b/server/src/main/resources/sample_data/persons/person134.json
@@ -1,0 +1,33 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1934-10-20",
+  "email": "c.schmitt@gmail.de",
+  "firstName": "Cornelius",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "D149153870",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "710571110305",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hauptstra\u00dfe 81",
+  "symptoms": [
+    "Schnupfen",
+    "Halschmerzen",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung",
+    "Husten",
+    "Fieber",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66488"
+}

--- a/server/src/main/resources/sample_data/persons/person135.json
+++ b/server/src/main/resources/sample_data/persons/person135.json
@@ -1,0 +1,28 @@
+{
+  "city": "Bous",
+  "coronaContacts": false,
+  "dateOfBirth": "1992-07-02",
+  "email": "j.richter@gmail.de",
+  "firstName": "Jens",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "P645818292",
+  "lastName": "Richter",
+  "nationality": "deutsch",
+  "phoneNumber": "1010917710982",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Steinstra\u00dfe 0",
+  "symptoms": [
+    "Schnupfen",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66808"
+}

--- a/server/src/main/resources/sample_data/persons/person136.json
+++ b/server/src/main/resources/sample_data/persons/person136.json
@@ -1,0 +1,28 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1955-06-10",
+  "email": "s.klein@gmail.de",
+  "firstName": "Susanne",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "V470756153",
+  "lastName": "Klein",
+  "nationality": "deutsch",
+  "phoneNumber": "7226984858",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Kronenstra\u00dfe 27",
+  "symptoms": [
+    "Schnupfen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66339"
+}

--- a/server/src/main/resources/sample_data/persons/person137.json
+++ b/server/src/main/resources/sample_data/persons/person137.json
@@ -1,0 +1,30 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": false,
+  "dateOfBirth": "1944-10-19",
+  "email": "c.winkler@web.de",
+  "firstName": "Christopher",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "Y943458769",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "106108460810",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Z\u00e4hringerstra\u00dfe 18",
+  "symptoms": [
+    "Schnupfen",
+    "Halschmerzen",
+    "Husten",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "660100"
+}

--- a/server/src/main/resources/sample_data/persons/person138.json
+++ b/server/src/main/resources/sample_data/persons/person138.json
@@ -1,0 +1,33 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1927-11-24",
+  "email": "i.schmitt@t-online.de",
+  "firstName": "Isabella",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "A898509546",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "831086384100",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Z\u00e4hringerstra\u00dfe 49",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Schnupfen",
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "666105"
+}

--- a/server/src/main/resources/sample_data/persons/person139.json
+++ b/server/src/main/resources/sample_data/persons/person139.json
@@ -1,0 +1,30 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": false,
+  "dateOfBirth": "1957-01-14",
+  "email": "h.berger@t-online.de",
+  "firstName": "Hans",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "Y771482340",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "4842294057",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Rosenstra\u00dfe 19",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66025"
+}

--- a/server/src/main/resources/sample_data/persons/person14.json
+++ b/server/src/main/resources/sample_data/persons/person14.json
@@ -1,33 +1,34 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": true,
-  "dateOfBirth": "1984-11-03",
-  "email": "a.bauer@gmx.de",
-  "firstName": "Annika",
+  "city": "V\u00f6lklingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1956-10-07",
+  "email": "s.berger@t-online.de",
+  "firstName": "Susanne",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 25,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "N776205431",
-  "lastName": "Bauer",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "D872830248",
+  "lastName": "Berger",
   "nationality": "deutsch",
-  "phoneNumber": "4810109513104",
+  "phoneNumber": "406088101035",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
     "Tirol"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Schernerweg",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Kaiserstra\u00dfe 8",
   "symptoms": [
-    "Gelenkschmerzen",
-    "Erk\u00e4ltung",
-    "Fieber",
+    "Atemschwierigkeiten",
     "Kopfschmerzen",
-    "Husten",
-    "Halschmerzen"
+    "Erk\u00e4ltung",
+    "Schnupfen",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Fieber",
+    "Husten"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "20037"
+  "weakenedImmuneSystem": true,
+  "zip": "661059"
 }

--- a/server/src/main/resources/sample_data/persons/person140.json
+++ b/server/src/main/resources/sample_data/persons/person140.json
@@ -1,0 +1,31 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": true,
+  "dateOfBirth": "1941-03-14",
+  "email": "h.berger@t-online.de",
+  "firstName": "Hans",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "Y797180693",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "88615331055",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hauptstra\u00dfe 37",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Fieber",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66398"
+}

--- a/server/src/main/resources/sample_data/persons/person141.json
+++ b/server/src/main/resources/sample_data/persons/person141.json
@@ -1,0 +1,27 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1973-09-24",
+  "email": "o.schulze@gmx.de",
+  "firstName": "Olivia",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "Y677646075",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "4085887704",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Kronenstra\u00dfe 24",
+  "symptoms": [
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66581"
+}

--- a/server/src/main/resources/sample_data/persons/person142.json
+++ b/server/src/main/resources/sample_data/persons/person142.json
@@ -1,0 +1,33 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1937-12-29",
+  "email": "i.schulze@posteo.de",
+  "firstName": "Isabella",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "H377721135",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "610110207501",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Haidth\u00f6heAarweg 6",
+  "symptoms": [
+    "Halschmerzen",
+    "Erk\u00e4ltung",
+    "Schnupfen",
+    "Husten",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66248"
+}

--- a/server/src/main/resources/sample_data/persons/person143.json
+++ b/server/src/main/resources/sample_data/persons/person143.json
@@ -1,0 +1,30 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1941-02-10",
+  "email": "m.schulz@gmail.de",
+  "firstName": "Matthias",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "Z956292577",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "104914766100",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Steinstra\u00dfe 20",
+  "symptoms": [
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66832"
+}

--- a/server/src/main/resources/sample_data/persons/person144.json
+++ b/server/src/main/resources/sample_data/persons/person144.json
@@ -1,0 +1,25 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": true,
+  "dateOfBirth": "1929-07-18",
+  "email": "p.peters@web.de",
+  "firstName": "Peter",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "F820457041",
+  "lastName": "Peters",
+  "nationality": "deutsch",
+  "phoneNumber": "81435361082",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Abbachstra\u00dfe 23",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "66394"
+}

--- a/server/src/main/resources/sample_data/persons/person145.json
+++ b/server/src/main/resources/sample_data/persons/person145.json
@@ -1,0 +1,28 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": false,
+  "dateOfBirth": "1993-04-24",
+  "email": "k.schulz@gmail.de",
+  "firstName": "Karl",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "T808049250",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "975521010314",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Eisenbahnstra\u00dfe 8",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66357"
+}

--- a/server/src/main/resources/sample_data/persons/person146.json
+++ b/server/src/main/resources/sample_data/persons/person146.json
@@ -1,0 +1,27 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1970-06-05",
+  "email": "a.klein@gmx.de",
+  "firstName": "Annika",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "G382646055",
+  "lastName": "Klein",
+  "nationality": "deutsch",
+  "phoneNumber": "10577754781",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Abbachstra\u00dfe 82",
+  "symptoms": [
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66914"
+}

--- a/server/src/main/resources/sample_data/persons/person147.json
+++ b/server/src/main/resources/sample_data/persons/person147.json
@@ -1,0 +1,28 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1935-05-18",
+  "email": "o.richter@t-online.de",
+  "firstName": "Olivia",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "A811545609",
+  "lastName": "Richter",
+  "nationality": "deutsch",
+  "phoneNumber": "87102563942",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Waldstra\u00dfe 64",
+  "symptoms": [
+    "Schnupfen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66816"
+}

--- a/server/src/main/resources/sample_data/persons/person148.json
+++ b/server/src/main/resources/sample_data/persons/person148.json
@@ -1,0 +1,30 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "1943-04-03",
+  "email": "m.mueller@posteo.de",
+  "firstName": "Marie",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "Q780287364",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "45301038567",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Waldstra\u00dfe 5",
+  "symptoms": [
+    "Schnupfen",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "660105"
+}

--- a/server/src/main/resources/sample_data/persons/person149.json
+++ b/server/src/main/resources/sample_data/persons/person149.json
@@ -1,0 +1,27 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1954-06-27",
+  "email": "s.klein@web.de",
+  "firstName": "Susanne",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "F488933925",
+  "lastName": "Klein",
+  "nationality": "deutsch",
+  "phoneNumber": "5779082723",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Haidth\u00f6heAarweg 65",
+  "symptoms": [
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "661043"
+}

--- a/server/src/main/resources/sample_data/persons/person15.json
+++ b/server/src/main/resources/sample_data/persons/person15.json
@@ -1,34 +1,31 @@
 {
-  "city": "D\u00fcsseldorf",
+  "city": "Heusweiler",
   "coronaContacts": true,
-  "dateOfBirth": "1990-08-05",
-  "email": "j.bauer@posteo.de",
-  "firstName": "Jana",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 57,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "P772966010",
-  "lastName": "Bauer",
+  "dateOfBirth": "1935-01-10",
+  "email": "b.schroeder@gmx.de",
+  "firstName": "Ben",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "J653462378",
+  "lastName": "Schr\u00f6der",
   "nationality": "deutsch",
-  "phoneNumber": "71088957986",
+  "phoneNumber": "43699105777",
   "preIllnesses": [
-    "Krebserkrankung"
+    ""
   ],
   "riskAreas": [
-    "Madrid"
+    "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "B\u00fcckerheide",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Bismarckstra\u00dfe 27",
   "symptoms": [
     "Fieber",
-    "Kopfschmerzen",
-    "Schnupfen",
-    "Gelenkschmerzen",
     "Halschmerzen",
-    "Atemschwierigkeiten",
-    "Erk\u00e4ltung"
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Kopfschmerzen"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "27743"
+  "zip": "66872"
 }

--- a/server/src/main/resources/sample_data/persons/person150.json
+++ b/server/src/main/resources/sample_data/persons/person150.json
@@ -1,0 +1,25 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": true,
+  "dateOfBirth": "1979-10-06",
+  "email": "e.schmidt@gmx.de",
+  "firstName": "Emma",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "I293313837",
+  "lastName": "Schmidt",
+  "nationality": "deutsch",
+  "phoneNumber": "10603029922",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Kronenstra\u00dfe 65",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "66092"
+}

--- a/server/src/main/resources/sample_data/persons/person151.json
+++ b/server/src/main/resources/sample_data/persons/person151.json
@@ -1,0 +1,28 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": false,
+  "dateOfBirth": "1945-08-06",
+  "email": "f.schmitt@web.de",
+  "firstName": "Franz",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "C346760672",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "36929291084",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Abbachstra\u00dfe 92",
+  "symptoms": [
+    "Fieber",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "661057"
+}

--- a/server/src/main/resources/sample_data/persons/person152.json
+++ b/server/src/main/resources/sample_data/persons/person152.json
@@ -1,0 +1,32 @@
+{
+  "city": "Homburg",
+  "coronaContacts": true,
+  "dateOfBirth": "1945-10-20",
+  "email": "b.schulze@posteo.de",
+  "firstName": "Ben",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "L146641502",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "08811710298",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordtstra\u00dfe 0",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "6610106"
+}

--- a/server/src/main/resources/sample_data/persons/person153.json
+++ b/server/src/main/resources/sample_data/persons/person153.json
@@ -1,0 +1,32 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": false,
+  "dateOfBirth": "1976-02-10",
+  "email": "a.bauer@gmx.de",
+  "firstName": "Anna",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "N488984224",
+  "lastName": "Bauer",
+  "nationality": "deutsch",
+  "phoneNumber": "9864300981",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hafenstra\u00dfe 0",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "666103"
+}

--- a/server/src/main/resources/sample_data/persons/person154.json
+++ b/server/src/main/resources/sample_data/persons/person154.json
@@ -1,0 +1,25 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1958-09-18",
+  "email": "p.schmidt@posteo.de",
+  "firstName": "Petra",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "Z463394867",
+  "lastName": "Schmidt",
+  "nationality": "deutsch",
+  "phoneNumber": "74495621013",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Waldstra\u00dfe 100",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "66213"
+}

--- a/server/src/main/resources/sample_data/persons/person155.json
+++ b/server/src/main/resources/sample_data/persons/person155.json
@@ -1,0 +1,29 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1929-07-03",
+  "email": "c.weber@gmx.de",
+  "firstName": "Cornelius",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "U630824004",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "1435190669",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Kronenstra\u00dfe 66",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66490"
+}

--- a/server/src/main/resources/sample_data/persons/person156.json
+++ b/server/src/main/resources/sample_data/persons/person156.json
@@ -1,0 +1,30 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": true,
+  "dateOfBirth": "1975-11-01",
+  "email": "f.mueller@gmail.de",
+  "firstName": "Fin",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "R725918919",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "21465106693",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Hafenstra\u00dfe 1",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66118"
+}

--- a/server/src/main/resources/sample_data/persons/person157.json
+++ b/server/src/main/resources/sample_data/persons/person157.json
@@ -1,0 +1,25 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1992-09-03",
+  "email": "a.sommer@web.de",
+  "firstName": "Anna",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "V594694805",
+  "lastName": "Sommer",
+  "nationality": "deutsch",
+  "phoneNumber": "8451848947",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Z\u00e4hringerstra\u00dfe 72",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "66735"
+}

--- a/server/src/main/resources/sample_data/persons/person158.json
+++ b/server/src/main/resources/sample_data/persons/person158.json
@@ -1,0 +1,30 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": false,
+  "dateOfBirth": "1965-07-31",
+  "email": "e.klein@posteo.de",
+  "firstName": "Emma",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "L334683594",
+  "lastName": "Klein",
+  "nationality": "deutsch",
+  "phoneNumber": "58804341610",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Tulpenweg 43",
+  "symptoms": [
+    "Schnupfen",
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66182"
+}

--- a/server/src/main/resources/sample_data/persons/person159.json
+++ b/server/src/main/resources/sample_data/persons/person159.json
@@ -1,0 +1,30 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1976-04-27",
+  "email": "c.bauer@posteo.de",
+  "firstName": "Cornelius",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "K628646448",
+  "lastName": "Bauer",
+  "nationality": "deutsch",
+  "phoneNumber": "395211110107",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Eisenbahnstra\u00dfe 0",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66807"
+}

--- a/server/src/main/resources/sample_data/persons/person16.json
+++ b/server/src/main/resources/sample_data/persons/person16.json
@@ -1,35 +1,29 @@
 {
-  "city": "D\u00fcsseldorf",
-  "coronaContacts": false,
-  "dateOfBirth": "1978-02-14",
-  "email": "f.richter@posteo.de",
+  "city": "Dudweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1996-08-14",
+  "email": "f.schmidt@web.de",
   "firstName": "Franz",
-  "fluImmunization": true,
+  "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 2,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "N677909930",
-  "lastName": "Richter",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "Q598806645",
+  "lastName": "Schmidt",
   "nationality": "deutsch",
-  "phoneNumber": "6587603669",
+  "phoneNumber": "109367632100",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "New York"
+    "Tirol"
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordufer",
+  "street": "B\u00fcckerheide 98",
   "symptoms": [
-    "Erk\u00e4ltung",
-    "Gelenkschmerzen",
     "Fieber",
-    "Schnupfen",
-    "Halschmerzen",
-    "Kopfschmerzen",
-    "Husten",
-    "Atemschwierigkeiten"
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "96705"
+  "zip": "66163"
 }

--- a/server/src/main/resources/sample_data/persons/person160.json
+++ b/server/src/main/resources/sample_data/persons/person160.json
@@ -1,0 +1,28 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "1936-01-17",
+  "email": "k.sommer@gmx.de",
+  "firstName": "Kai",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "L757965465",
+  "lastName": "Sommer",
+  "nationality": "deutsch",
+  "phoneNumber": "56102718750",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Aarhusweg 86",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66369"
+}

--- a/server/src/main/resources/sample_data/persons/person161.json
+++ b/server/src/main/resources/sample_data/persons/person161.json
@@ -1,0 +1,28 @@
+{
+  "city": "Bous",
+  "coronaContacts": false,
+  "dateOfBirth": "1979-07-23",
+  "email": "a.schmidt@gmx.de",
+  "firstName": "Anna",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "G256598517",
+  "lastName": "Schmidt",
+  "nationality": "deutsch",
+  "phoneNumber": "55647292910",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Abbendiekshof 12",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66438"
+}

--- a/server/src/main/resources/sample_data/persons/person162.json
+++ b/server/src/main/resources/sample_data/persons/person162.json
@@ -1,0 +1,31 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": true,
+  "dateOfBirth": "1965-08-10",
+  "email": "k.berger@web.de",
+  "firstName": "Konrad",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "L701671267",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "4890612034",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Steinstra\u00dfe 80",
+  "symptoms": [
+    "Husten",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66175"
+}

--- a/server/src/main/resources/sample_data/persons/person163.json
+++ b/server/src/main/resources/sample_data/persons/person163.json
@@ -1,0 +1,31 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "1943-12-15",
+  "email": "m.lange@web.de",
+  "firstName": "Marie",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "F468965063",
+  "lastName": "Lange",
+  "nationality": "deutsch",
+  "phoneNumber": "169471022105",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Kaiserstra\u00dfe 80",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66996"
+}

--- a/server/src/main/resources/sample_data/persons/person164.json
+++ b/server/src/main/resources/sample_data/persons/person164.json
@@ -1,0 +1,27 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "2003-03-24",
+  "email": "s.wagner@posteo.de",
+  "firstName": "Susanne",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "D381805975",
+  "lastName": "Wagner",
+  "nationality": "deutsch",
+  "phoneNumber": "31041326111",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Steinstra\u00dfe 70",
+  "symptoms": [
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66006"
+}

--- a/server/src/main/resources/sample_data/persons/person165.json
+++ b/server/src/main/resources/sample_data/persons/person165.json
@@ -1,0 +1,32 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": false,
+  "dateOfBirth": "1938-03-01",
+  "email": "e.weber@posteo.de",
+  "firstName": "Emma",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "U904137710",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "01055778487",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Aastwiete 89",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Fieber",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66829"
+}

--- a/server/src/main/resources/sample_data/persons/person166.json
+++ b/server/src/main/resources/sample_data/persons/person166.json
@@ -1,0 +1,34 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": false,
+  "dateOfBirth": "2005-09-27",
+  "email": "a.schroeder@t-online.de",
+  "firstName": "Anna",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "R501197060",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "2547807740",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "B\u00fcckerheide 55",
+  "symptoms": [
+    "Halschmerzen",
+    "Erk\u00e4ltung",
+    "Fieber",
+    "Kopfschmerzen",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Husten",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66493"
+}

--- a/server/src/main/resources/sample_data/persons/person167.json
+++ b/server/src/main/resources/sample_data/persons/person167.json
@@ -1,0 +1,28 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1981-02-06",
+  "email": "p.bauer@gmx.de",
+  "firstName": "Petra",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "F209815321",
+  "lastName": "Bauer",
+  "nationality": "deutsch",
+  "phoneNumber": "24110797497",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Niekampsweg 41",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66020"
+}

--- a/server/src/main/resources/sample_data/persons/person168.json
+++ b/server/src/main/resources/sample_data/persons/person168.json
@@ -1,0 +1,29 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": false,
+  "dateOfBirth": "1952-05-26",
+  "email": "j.richter@gmail.de",
+  "firstName": "Jens",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "A230955221",
+  "lastName": "Richter",
+  "nationality": "deutsch",
+  "phoneNumber": "7570512046",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Haidth\u00f6heAarweg 69",
+  "symptoms": [
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66723"
+}

--- a/server/src/main/resources/sample_data/persons/person169.json
+++ b/server/src/main/resources/sample_data/persons/person169.json
@@ -1,0 +1,32 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": true,
+  "dateOfBirth": "1979-08-13",
+  "email": "j.schulze@web.de",
+  "firstName": "Jens",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "G221256011",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "104521008814",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Steinstra\u00dfe 81",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Husten",
+    "Fieber",
+    "Schnupfen",
+    "Halschmerzen",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66435"
+}

--- a/server/src/main/resources/sample_data/persons/person17.json
+++ b/server/src/main/resources/sample_data/persons/person17.json
@@ -1,31 +1,27 @@
 {
-  "city": "Kiel",
+  "city": "St. Ingbert",
   "coronaContacts": false,
-  "dateOfBirth": "1937-01-30",
-  "email": "j.schulz@web.de",
-  "firstName": "Jens",
-  "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 6,
+  "dateOfBirth": "1935-08-29",
+  "email": "m.berger@gmx.de",
+  "firstName": "Martina",
+  "fluImmunization": true,
+  "gender": "female",
   "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "Y507083673",
-  "lastName": "Schulz",
+  "insuranceMembershipNumber": "K443285529",
+  "lastName": "Berger",
   "nationality": "deutsch",
-  "phoneNumber": "699100110627",
+  "phoneNumber": "277431048710",
   "preIllnesses": [
-    ""
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Hubei"
+    "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Haidth\u00f6heAarweg",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Abbendiekshof 35",
   "symptoms": [
-    "Fieber",
-    "Erk\u00e4ltung",
-    "Husten",
-    "Atemschwierigkeiten"
+    "Schnupfen"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "46537"
+  "zip": "66714"
 }

--- a/server/src/main/resources/sample_data/persons/person170.json
+++ b/server/src/main/resources/sample_data/persons/person170.json
@@ -1,0 +1,31 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": false,
+  "dateOfBirth": "1994-04-06",
+  "email": "h.weber@gmail.de",
+  "firstName": "Hanna",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "K699524216",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "7110951000510",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Aastwiete 89",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Fieber",
+    "Husten",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66812"
+}

--- a/server/src/main/resources/sample_data/persons/person171.json
+++ b/server/src/main/resources/sample_data/persons/person171.json
@@ -1,0 +1,31 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1968-09-23",
+  "email": "j.schmitt@web.de",
+  "firstName": "Jens",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "J979843968",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "7392855749",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordufer 70",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Husten",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66218"
+}

--- a/server/src/main/resources/sample_data/persons/person172.json
+++ b/server/src/main/resources/sample_data/persons/person172.json
@@ -1,0 +1,28 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1997-11-18",
+  "email": "o.klein@gmail.de",
+  "firstName": "Olivia",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "C147005473",
+  "lastName": "Klein",
+  "nationality": "deutsch",
+  "phoneNumber": "63810782945",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Kaiserstra\u00dfe 82",
+  "symptoms": [
+    "Husten",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66511"
+}

--- a/server/src/main/resources/sample_data/persons/person173.json
+++ b/server/src/main/resources/sample_data/persons/person173.json
@@ -1,0 +1,25 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1938-10-23",
+  "email": "b.winter@gmx.de",
+  "firstName": "Ben",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "X546626348",
+  "lastName": "Winter",
+  "nationality": "deutsch",
+  "phoneNumber": "94053910310",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Steinstra\u00dfe 10",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "667100"
+}

--- a/server/src/main/resources/sample_data/persons/person174.json
+++ b/server/src/main/resources/sample_data/persons/person174.json
@@ -1,0 +1,33 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1978-09-04",
+  "email": "c.schroeder@t-online.de",
+  "firstName": "Cornelius",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "Y785717617",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "13863381039",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Kronenstra\u00dfe 22",
+  "symptoms": [
+    "Halschmerzen",
+    "Husten",
+    "Fieber",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung",
+    "Schnupfen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66886"
+}

--- a/server/src/main/resources/sample_data/persons/person175.json
+++ b/server/src/main/resources/sample_data/persons/person175.json
@@ -1,0 +1,25 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": false,
+  "dateOfBirth": "1953-11-14",
+  "email": "m.lange@gmail.de",
+  "firstName": "Marie",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "A655778818",
+  "lastName": "Lange",
+  "nationality": "deutsch",
+  "phoneNumber": "5939836845",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Waldstra\u00dfe 57",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "66600"
+}

--- a/server/src/main/resources/sample_data/persons/person176.json
+++ b/server/src/main/resources/sample_data/persons/person176.json
@@ -1,0 +1,27 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1940-09-19",
+  "email": "c.bauer@web.de",
+  "firstName": "Christopher",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "M711028819",
+  "lastName": "Bauer",
+  "nationality": "deutsch",
+  "phoneNumber": "9210752245",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hohenzollerstra\u00dfe 31",
+  "symptoms": [
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66344"
+}

--- a/server/src/main/resources/sample_data/persons/person177.json
+++ b/server/src/main/resources/sample_data/persons/person177.json
@@ -1,0 +1,28 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": true,
+  "dateOfBirth": "1932-07-03",
+  "email": "b.schroeder@t-online.de",
+  "firstName": "Ben",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "B442863523",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "05566131090",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Kronenstra\u00dfe 99",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "661060"
+}

--- a/server/src/main/resources/sample_data/persons/person178.json
+++ b/server/src/main/resources/sample_data/persons/person178.json
@@ -1,0 +1,34 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1977-07-10",
+  "email": "d.berger@t-online.de",
+  "firstName": "Daniela",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "E918226618",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "6225179086",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Sonnenweg 10",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Schnupfen",
+    "Husten",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66686"
+}

--- a/server/src/main/resources/sample_data/persons/person179.json
+++ b/server/src/main/resources/sample_data/persons/person179.json
@@ -1,0 +1,27 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": true,
+  "dateOfBirth": "1953-07-12",
+  "email": "e.schulz@t-online.de",
+  "firstName": "Emma",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "G835898867",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "53559100425",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Eisenbahnstra\u00dfe 56",
+  "symptoms": [
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66927"
+}

--- a/server/src/main/resources/sample_data/persons/person18.json
+++ b/server/src/main/resources/sample_data/persons/person18.json
@@ -1,33 +1,29 @@
 {
-  "city": "Berlin",
-  "coronaContacts": true,
-  "dateOfBirth": "2003-10-05",
-  "email": "p.schulze@posteo.de",
-  "firstName": "Peter",
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1963-09-15",
+  "email": "d.sommer@gmx.de",
+  "firstName": "Daniel",
   "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 77,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "S827296111",
-  "lastName": "Schulze",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "X686405096",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "32710193745",
+  "phoneNumber": "6036690967",
   "preIllnesses": [
-    ""
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Hubei"
+    "Tirol"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Haidth\u00f6heAarweg",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Aarhusweg 45",
   "symptoms": [
-    "Erk\u00e4ltung",
-    "Husten",
-    "Atemschwierigkeiten",
+    "Gelenkschmerzen",
     "Fieber",
-    "Halschmerzen",
     "Schnupfen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "91241"
+  "weakenedImmuneSystem": false,
+  "zip": "66466"
 }

--- a/server/src/main/resources/sample_data/persons/person180.json
+++ b/server/src/main/resources/sample_data/persons/person180.json
@@ -1,0 +1,28 @@
+{
+  "city": "Bous",
+  "coronaContacts": false,
+  "dateOfBirth": "1966-08-16",
+  "email": "j.lange@t-online.de",
+  "firstName": "Jana",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "V665646221",
+  "lastName": "Lange",
+  "nationality": "deutsch",
+  "phoneNumber": "0538338848",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Steinstra\u00dfe 79",
+  "symptoms": [
+    "Husten",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "662100"
+}

--- a/server/src/main/resources/sample_data/persons/person181.json
+++ b/server/src/main/resources/sample_data/persons/person181.json
@@ -1,0 +1,33 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": false,
+  "dateOfBirth": "1956-11-09",
+  "email": "j.peters@t-online.de",
+  "firstName": "Jens",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "C300164147",
+  "lastName": "Peters",
+  "nationality": "deutsch",
+  "phoneNumber": "1010510410636",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Hafenstra\u00dfe 90",
+  "symptoms": [
+    "Husten",
+    "Gelenkschmerzen",
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66157"
+}

--- a/server/src/main/resources/sample_data/persons/person182.json
+++ b/server/src/main/resources/sample_data/persons/person182.json
@@ -1,0 +1,29 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "1925-05-08",
+  "email": "e.winkler@gmail.de",
+  "firstName": "Emma",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "M659116527",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "84010460843",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Aastwiete 43",
+  "symptoms": [
+    "Halschmerzen",
+    "Fieber",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "666102"
+}

--- a/server/src/main/resources/sample_data/persons/person183.json
+++ b/server/src/main/resources/sample_data/persons/person183.json
@@ -1,0 +1,25 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1988-10-18",
+  "email": "d.weber@posteo.de",
+  "firstName": "Daniela",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "F441017812",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "103248262109",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Abbachstra\u00dfe 40",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "66188"
+}

--- a/server/src/main/resources/sample_data/persons/person184.json
+++ b/server/src/main/resources/sample_data/persons/person184.json
@@ -1,0 +1,34 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1986-04-04",
+  "email": "p.schmitt@gmail.de",
+  "firstName": "Petra",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "W937332060",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "2209949993",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Eisenbahnstra\u00dfe 29",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Schnupfen",
+    "Fieber",
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "663100"
+}

--- a/server/src/main/resources/sample_data/persons/person185.json
+++ b/server/src/main/resources/sample_data/persons/person185.json
@@ -1,0 +1,34 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1953-04-24",
+  "email": "j.peters@gmail.de",
+  "firstName": "Jan",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "X435971123",
+  "lastName": "Peters",
+  "nationality": "deutsch",
+  "phoneNumber": "10331279757",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Abbendiekshof 54",
+  "symptoms": [
+    "Husten",
+    "Atemschwierigkeiten",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66609"
+}

--- a/server/src/main/resources/sample_data/persons/person186.json
+++ b/server/src/main/resources/sample_data/persons/person186.json
@@ -1,0 +1,34 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1955-05-25",
+  "email": "f.schroeder@gmx.de",
+  "firstName": "Franz",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "Y728619698",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "4726490827",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordtstra\u00dfe 82",
+  "symptoms": [
+    "Schnupfen",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Husten",
+    "Atemschwierigkeiten",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66718"
+}

--- a/server/src/main/resources/sample_data/persons/person187.json
+++ b/server/src/main/resources/sample_data/persons/person187.json
@@ -1,0 +1,28 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1985-12-24",
+  "email": "l.bauer@gmail.de",
+  "firstName": "Lisa",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "K707191953",
+  "lastName": "Bauer",
+  "nationality": "deutsch",
+  "phoneNumber": "11171051868",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Eisenbahnstra\u00dfe 20",
+  "symptoms": [
+    "Schnupfen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66686"
+}

--- a/server/src/main/resources/sample_data/persons/person188.json
+++ b/server/src/main/resources/sample_data/persons/person188.json
@@ -1,0 +1,33 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": true,
+  "dateOfBirth": "1969-11-06",
+  "email": "p.schroeder@gmx.de",
+  "firstName": "Petra",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "V610791858",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "1230940777",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Poststra\u00dfe 0",
+  "symptoms": [
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Halschmerzen",
+    "Husten",
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66973"
+}

--- a/server/src/main/resources/sample_data/persons/person189.json
+++ b/server/src/main/resources/sample_data/persons/person189.json
@@ -1,0 +1,28 @@
+{
+  "city": "Heusweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1961-01-05",
+  "email": "h.weber@t-online.de",
+  "firstName": "Hans",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "W738843080",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "01099451016",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Abbachstra\u00dfe 20",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "661049"
+}

--- a/server/src/main/resources/sample_data/persons/person19.json
+++ b/server/src/main/resources/sample_data/persons/person19.json
@@ -1,31 +1,32 @@
 {
-  "city": "Frankfurt",
+  "city": "Bous",
   "coronaContacts": false,
-  "dateOfBirth": "1958-02-17",
-  "email": "t.bauer@gmx.de",
-  "firstName": "Tim",
-  "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 19,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "O567694547",
-  "lastName": "Bauer",
+  "dateOfBirth": "1946-03-20",
+  "email": "e.winter@posteo.de",
+  "firstName": "Emma",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "G588229686",
+  "lastName": "Winter",
   "nationality": "deutsch",
-  "phoneNumber": "105067165107",
+  "phoneNumber": "806991001106",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    ""
   ],
   "riskAreas": [
-    "Tirol"
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordufer",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Aastwiete 59",
   "symptoms": [
-    "Kopfschmerzen",
+    "Atemschwierigkeiten",
     "Halschmerzen",
-    "Fieber",
-    "Husten"
+    "Erk\u00e4ltung",
+    "Schnupfen",
+    "Husten",
+    "Fieber"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "628104"
+  "weakenedImmuneSystem": true,
+  "zip": "66204"
 }

--- a/server/src/main/resources/sample_data/persons/person190.json
+++ b/server/src/main/resources/sample_data/persons/person190.json
@@ -1,0 +1,34 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": true,
+  "dateOfBirth": "1958-07-27",
+  "email": "c.schroeder@gmail.de",
+  "firstName": "Christopher",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "D713500721",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "1681472145",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Hafenstra\u00dfe 52",
+  "symptoms": [
+    "Fieber",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Halschmerzen",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66833"
+}

--- a/server/src/main/resources/sample_data/persons/person191.json
+++ b/server/src/main/resources/sample_data/persons/person191.json
@@ -1,0 +1,29 @@
+{
+  "city": "Bous",
+  "coronaContacts": true,
+  "dateOfBirth": "1925-08-16",
+  "email": "b.schmidt@web.de",
+  "firstName": "Ben",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "K475433873",
+  "lastName": "Schmidt",
+  "nationality": "deutsch",
+  "phoneNumber": "29343010710",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordstra\u00dfe 15",
+  "symptoms": [
+    "Husten",
+    "Kopfschmerzen",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66396"
+}

--- a/server/src/main/resources/sample_data/persons/person192.json
+++ b/server/src/main/resources/sample_data/persons/person192.json
@@ -1,0 +1,33 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1964-01-04",
+  "email": "p.berger@web.de",
+  "firstName": "Petra",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "U245764637",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "10556990235",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Nordtstra\u00dfe 43",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Husten",
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "661077"
+}

--- a/server/src/main/resources/sample_data/persons/person193.json
+++ b/server/src/main/resources/sample_data/persons/person193.json
@@ -1,0 +1,31 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": false,
+  "dateOfBirth": "1986-05-27",
+  "email": "o.winkler@t-online.de",
+  "firstName": "Olivia",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "C633708134",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "05610829962",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Eisenbahnstra\u00dfe 14",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Halschmerzen",
+    "Schnupfen",
+    "Fieber",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66450"
+}

--- a/server/src/main/resources/sample_data/persons/person194.json
+++ b/server/src/main/resources/sample_data/persons/person194.json
@@ -1,0 +1,34 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": false,
+  "dateOfBirth": "1941-01-26",
+  "email": "k.schulz@gmx.de",
+  "firstName": "Konrad",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "B593243074",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "7823578452",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "B\u00fcckerheide 12",
+  "symptoms": [
+    "Fieber",
+    "Husten",
+    "Schnupfen",
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "668102"
+}

--- a/server/src/main/resources/sample_data/persons/person195.json
+++ b/server/src/main/resources/sample_data/persons/person195.json
@@ -1,0 +1,31 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1964-04-07",
+  "email": "b.schroeder@posteo.de",
+  "firstName": "Ben",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "G682535775",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "44857101422",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Sonnenweg 14",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66098"
+}

--- a/server/src/main/resources/sample_data/persons/person196.json
+++ b/server/src/main/resources/sample_data/persons/person196.json
@@ -1,0 +1,34 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": false,
+  "dateOfBirth": "1945-11-02",
+  "email": "j.weber@t-online.de",
+  "firstName": "Jana",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "G865469134",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "16016629910",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordtstra\u00dfe 88",
+  "symptoms": [
+    "Fieber",
+    "Halschmerzen",
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Gelenkschmerzen",
+    "Husten",
+    "Kopfschmerzen",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66795"
+}

--- a/server/src/main/resources/sample_data/persons/person197.json
+++ b/server/src/main/resources/sample_data/persons/person197.json
@@ -1,0 +1,28 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1927-05-30",
+  "email": "a.klein@posteo.de",
+  "firstName": "Annika",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "Y474322976",
+  "lastName": "Klein",
+  "nationality": "deutsch",
+  "phoneNumber": "56210557701",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Steinstra\u00dfe 14",
+  "symptoms": [
+    "Fieber",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66577"
+}

--- a/server/src/main/resources/sample_data/persons/person198.json
+++ b/server/src/main/resources/sample_data/persons/person198.json
@@ -1,0 +1,27 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": false,
+  "dateOfBirth": "1937-08-13",
+  "email": "p.schulz@gmail.de",
+  "firstName": "Petra",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "R845319806",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "9639382761",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "S\u00fcdweg 26",
+  "symptoms": [
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66966"
+}

--- a/server/src/main/resources/sample_data/persons/person199.json
+++ b/server/src/main/resources/sample_data/persons/person199.json
@@ -1,0 +1,28 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": false,
+  "dateOfBirth": "1983-05-31",
+  "email": "p.schulze@gmx.de",
+  "firstName": "Petra",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "Z100197929",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "619110965710",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Bismarckstra\u00dfe 7",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66132"
+}

--- a/server/src/main/resources/sample_data/persons/person2.json
+++ b/server/src/main/resources/sample_data/persons/person2.json
@@ -1,31 +1,34 @@
 {
-  "city": "Berlin",
+  "city": "Riegelsberg",
   "coronaContacts": false,
-  "dateOfBirth": "1971-12-30",
-  "email": "t.wagner@posteo.de",
-  "firstName": "Tim",
+  "dateOfBirth": "1957-05-15",
+  "email": "c.klein@t-online.de",
+  "firstName": "Cornelius",
   "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 34,
   "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "B964411347",
-  "lastName": "Wagner",
+  "insuranceMembershipNumber": "F596348124",
+  "lastName": "Klein",
   "nationality": "deutsch",
-  "phoneNumber": "1010191028327",
+  "phoneNumber": "10525531041010",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "New York"
+    ""
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Niekampsweg",
+  "street": "Haidth\u00f6heAarweg 77",
   "symptoms": [
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Husten",
     "Fieber",
-    "Gelenkschmerzen",
     "Atemschwierigkeiten",
-    "Schnupfen"
+    "Gelenkschmerzen",
+    "Halschmerzen"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "1083105"
+  "zip": "661028"
 }

--- a/server/src/main/resources/sample_data/persons/person20.json
+++ b/server/src/main/resources/sample_data/persons/person20.json
@@ -1,28 +1,30 @@
 {
-  "city": "Bochum",
-  "coronaContacts": false,
-  "dateOfBirth": "1964-03-16",
-  "email": "m.peters@gmx.de",
-  "firstName": "Marie",
+  "city": "Kirkel",
+  "coronaContacts": true,
+  "dateOfBirth": "2002-04-07",
+  "email": "a.schulz@t-online.de",
+  "firstName": "Annika",
   "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 10,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "W627015393",
-  "lastName": "Peters",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "X871330207",
+  "lastName": "Schulz",
   "nationality": "deutsch",
-  "phoneNumber": "3545494808",
+  "phoneNumber": "09232710193",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Tirol"
+    "New York"
   ],
   "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Schernerweg",
+  "street": "Waldstra\u00dfe 89",
   "symptoms": [
-    "Atemschwierigkeiten"
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Husten",
+    "Schnupfen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "36783"
+  "zip": "66452"
 }

--- a/server/src/main/resources/sample_data/persons/person200.json
+++ b/server/src/main/resources/sample_data/persons/person200.json
@@ -1,0 +1,25 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": false,
+  "dateOfBirth": "1933-11-10",
+  "email": "f.lange@gmail.de",
+  "firstName": "Franz",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "L217787669",
+  "lastName": "Lange",
+  "nationality": "deutsch",
+  "phoneNumber": "6519098624",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Im KramersfeldAar\u00f6stra\u00dfe 47",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "66800"
+}

--- a/server/src/main/resources/sample_data/persons/person201.json
+++ b/server/src/main/resources/sample_data/persons/person201.json
@@ -1,0 +1,33 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": true,
+  "dateOfBirth": "1957-07-18",
+  "email": "h.winter@gmx.de",
+  "firstName": "Hanna",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "U116866122",
+  "lastName": "Winter",
+  "nationality": "deutsch",
+  "phoneNumber": "31027238656",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Aastwiete 36",
+  "symptoms": [
+    "Halschmerzen",
+    "Fieber",
+    "Husten",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "661022"
+}

--- a/server/src/main/resources/sample_data/persons/person202.json
+++ b/server/src/main/resources/sample_data/persons/person202.json
@@ -1,0 +1,34 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1982-07-20",
+  "email": "s.winkler@posteo.de",
+  "firstName": "Susanne",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "P841415799",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "0973846895",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Im KramersfeldAar\u00f6stra\u00dfe 4",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Husten",
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Fieber",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66975"
+}

--- a/server/src/main/resources/sample_data/persons/person203.json
+++ b/server/src/main/resources/sample_data/persons/person203.json
@@ -1,0 +1,25 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": true,
+  "dateOfBirth": "2004-08-15",
+  "email": "k.lange@web.de",
+  "firstName": "Konrad",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "P720774271",
+  "lastName": "Lange",
+  "nationality": "deutsch",
+  "phoneNumber": "8795654420",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Rosenstra\u00dfe 76",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "66494"
+}

--- a/server/src/main/resources/sample_data/persons/person204.json
+++ b/server/src/main/resources/sample_data/persons/person204.json
@@ -1,0 +1,33 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1941-02-28",
+  "email": "d.schulz@posteo.de",
+  "firstName": "Daniela",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "I940232725",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "4429444019",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Abbachstra\u00dfe 75",
+  "symptoms": [
+    "Schnupfen",
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Husten",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "662107"
+}

--- a/server/src/main/resources/sample_data/persons/person205.json
+++ b/server/src/main/resources/sample_data/persons/person205.json
@@ -1,0 +1,32 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": false,
+  "dateOfBirth": "1949-12-21",
+  "email": "o.winter@posteo.de",
+  "firstName": "Olivia",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "H507807998",
+  "lastName": "Winter",
+  "nationality": "deutsch",
+  "phoneNumber": "23950104102",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Waldstra\u00dfe 51",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66747"
+}

--- a/server/src/main/resources/sample_data/persons/person206.json
+++ b/server/src/main/resources/sample_data/persons/person206.json
@@ -1,0 +1,31 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1937-11-12",
+  "email": "p.mueller@t-online.de",
+  "firstName": "Petra",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "S927315167",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "691045441410",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Hohenzollerstra\u00dfe 50",
+  "symptoms": [
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Husten",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "667103"
+}

--- a/server/src/main/resources/sample_data/persons/person207.json
+++ b/server/src/main/resources/sample_data/persons/person207.json
@@ -1,0 +1,28 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": false,
+  "dateOfBirth": "1961-04-24",
+  "email": "k.schulze@gmx.de",
+  "firstName": "Kai",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "C749276419",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "44300910910",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Nordtstra\u00dfe 27",
+  "symptoms": [
+    "Fieber",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "669101"
+}

--- a/server/src/main/resources/sample_data/persons/person208.json
+++ b/server/src/main/resources/sample_data/persons/person208.json
@@ -1,0 +1,33 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1951-12-29",
+  "email": "f.schmitt@gmail.de",
+  "firstName": "Fin",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "G755306663",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "10542140665",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Im KramersfeldAar\u00f6stra\u00dfe 33",
+  "symptoms": [
+    "Fieber",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Schnupfen",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66427"
+}

--- a/server/src/main/resources/sample_data/persons/person209.json
+++ b/server/src/main/resources/sample_data/persons/person209.json
@@ -1,0 +1,32 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1932-12-09",
+  "email": "p.schulz@t-online.de",
+  "firstName": "Peter",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "W927844881",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "7072101000106",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Sonnenweg 19",
+  "symptoms": [
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Husten",
+    "Fieber",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66569"
+}

--- a/server/src/main/resources/sample_data/persons/person21.json
+++ b/server/src/main/resources/sample_data/persons/person21.json
@@ -1,31 +1,33 @@
 {
-  "city": "D\u00fcsseldorf",
-  "coronaContacts": false,
-  "dateOfBirth": "1938-06-14",
-  "email": "m.klein@web.de",
-  "firstName": "Marie",
+  "city": "Homburg",
+  "coronaContacts": true,
+  "dateOfBirth": "1930-12-27",
+  "email": "h.richter@t-online.de",
+  "firstName": "Hanna",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 15,
   "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "S916267011",
-  "lastName": "Klein",
+  "insuranceMembershipNumber": "K113585139",
+  "lastName": "Richter",
   "nationality": "deutsch",
-  "phoneNumber": "8557444313",
+  "phoneNumber": "103141091905",
   "preIllnesses": [
     "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Hubei"
+    "Madrid"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Abbachstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Poststra\u00dfe 54",
   "symptoms": [
     "Fieber",
+    "Erk\u00e4ltung",
+    "Schnupfen",
     "Halschmerzen",
     "Gelenkschmerzen",
-    "Schnupfen"
+    "Atemschwierigkeiten",
+    "Husten"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "82337"
+  "weakenedImmuneSystem": true,
+  "zip": "661051"
 }

--- a/server/src/main/resources/sample_data/persons/person210.json
+++ b/server/src/main/resources/sample_data/persons/person210.json
@@ -1,0 +1,31 @@
+{
+  "city": "Heusweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1967-07-02",
+  "email": "b.winkler@gmail.de",
+  "firstName": "Ben",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "J847197907",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "1010158517410",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Niekampsweg 22",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Husten",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66806"
+}

--- a/server/src/main/resources/sample_data/persons/person211.json
+++ b/server/src/main/resources/sample_data/persons/person211.json
@@ -1,0 +1,29 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": false,
+  "dateOfBirth": "1936-11-10",
+  "email": "j.winter@t-online.de",
+  "firstName": "Jens",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "R259937739",
+  "lastName": "Winter",
+  "nationality": "deutsch",
+  "phoneNumber": "7870050506",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Schernerweg 27",
+  "symptoms": [
+    "Fieber",
+    "Husten",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "6610108"
+}

--- a/server/src/main/resources/sample_data/persons/person212.json
+++ b/server/src/main/resources/sample_data/persons/person212.json
@@ -1,0 +1,32 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1989-01-06",
+  "email": "m.mueller@posteo.de",
+  "firstName": "Martina",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "N462219407",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "10041792911",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Schernerweg 63",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Husten",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66993"
+}

--- a/server/src/main/resources/sample_data/persons/person213.json
+++ b/server/src/main/resources/sample_data/persons/person213.json
@@ -1,0 +1,27 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1970-03-25",
+  "email": "t.schulz@t-online.de",
+  "firstName": "Tim",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "C106817809",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "6258273902",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Schernerweg 80",
+  "symptoms": [
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66962"
+}

--- a/server/src/main/resources/sample_data/persons/person214.json
+++ b/server/src/main/resources/sample_data/persons/person214.json
@@ -1,0 +1,27 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": true,
+  "dateOfBirth": "1939-08-14",
+  "email": "f.weber@gmail.de",
+  "firstName": "Franz",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "H306054135",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "32909279110",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordtstra\u00dfe 100",
+  "symptoms": [
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66456"
+}

--- a/server/src/main/resources/sample_data/persons/person215.json
+++ b/server/src/main/resources/sample_data/persons/person215.json
@@ -1,0 +1,27 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1999-04-04",
+  "email": "o.richter@gmail.de",
+  "firstName": "Olivia",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "Z914334414",
+  "lastName": "Richter",
+  "nationality": "deutsch",
+  "phoneNumber": "2107722100010",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hauptstra\u00dfe 36",
+  "symptoms": [
+    "Husten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66364"
+}

--- a/server/src/main/resources/sample_data/persons/person216.json
+++ b/server/src/main/resources/sample_data/persons/person216.json
@@ -1,0 +1,33 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": false,
+  "dateOfBirth": "1996-04-24",
+  "email": "j.berger@t-online.de",
+  "firstName": "Jens",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "H178951929",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "79956310531",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "S\u00fcdweg 29",
+  "symptoms": [
+    "Husten",
+    "Erk\u00e4ltung",
+    "Fieber",
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66136"
+}

--- a/server/src/main/resources/sample_data/persons/person217.json
+++ b/server/src/main/resources/sample_data/persons/person217.json
@@ -1,0 +1,27 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": true,
+  "dateOfBirth": "1989-01-23",
+  "email": "p.richter@gmail.de",
+  "firstName": "Petra",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "S693516844",
+  "lastName": "Richter",
+  "nationality": "deutsch",
+  "phoneNumber": "9042177625",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Abbendiekshof 37",
+  "symptoms": [
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "669210"
+}

--- a/server/src/main/resources/sample_data/persons/person218.json
+++ b/server/src/main/resources/sample_data/persons/person218.json
@@ -1,0 +1,27 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "2004-12-14",
+  "email": "i.schmitt@gmail.de",
+  "firstName": "Isabella",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "Q523398047",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "3356939290",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Kaiserstra\u00dfe 5",
+  "symptoms": [
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66078"
+}

--- a/server/src/main/resources/sample_data/persons/person219.json
+++ b/server/src/main/resources/sample_data/persons/person219.json
@@ -1,0 +1,25 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1968-04-21",
+  "email": "a.weber@gmail.de",
+  "firstName": "Annika",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "U598533805",
+  "lastName": "Weber",
+  "nationality": "deutsch",
+  "phoneNumber": "10710427990",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Waldstra\u00dfe 59",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "66262"
+}

--- a/server/src/main/resources/sample_data/persons/person22.json
+++ b/server/src/main/resources/sample_data/persons/person22.json
@@ -1,26 +1,30 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": false,
-  "dateOfBirth": "2000-01-18",
-  "email": "k.schulz@gmail.de",
-  "firstName": "Kai",
-  "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 43,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "P179545125",
-  "lastName": "Schulz",
+  "city": "Neunkirchen",
+  "coronaContacts": true,
+  "dateOfBirth": "1971-06-28",
+  "email": "d.sommer@web.de",
+  "firstName": "Daniela",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "L956665975",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "42107109477",
+  "phoneNumber": "31473799106",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Krebserkrankung"
   ],
   "riskAreas": [
     "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Abbendiekshof",
-  "symptoms": [],
-  "weakenedImmuneSystem": true,
-  "zip": "20471"
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "S\u00fcdweg 3",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Gelenkschmerzen",
+    "Husten",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66752"
 }

--- a/server/src/main/resources/sample_data/persons/person220.json
+++ b/server/src/main/resources/sample_data/persons/person220.json
@@ -1,0 +1,28 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1951-05-23",
+  "email": "p.mueller@gmail.de",
+  "firstName": "Petra",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "T143888484",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "98931019508",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Bismarckstra\u00dfe 46",
+  "symptoms": [
+    "Fieber",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66016"
+}

--- a/server/src/main/resources/sample_data/persons/person221.json
+++ b/server/src/main/resources/sample_data/persons/person221.json
@@ -1,0 +1,34 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1931-12-07",
+  "email": "a.schulze@gmx.de",
+  "firstName": "Annika",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "P862169097",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "35548106401",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Hauptstra\u00dfe 44",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Husten",
+    "Halschmerzen",
+    "Fieber",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66778"
+}

--- a/server/src/main/resources/sample_data/persons/person222.json
+++ b/server/src/main/resources/sample_data/persons/person222.json
@@ -1,0 +1,27 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": true,
+  "dateOfBirth": "1970-02-23",
+  "email": "l.schulze@posteo.de",
+  "firstName": "Lisa",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "U123066440",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "272381004610",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Poststra\u00dfe 16",
+  "symptoms": [
+    "Husten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66756"
+}

--- a/server/src/main/resources/sample_data/persons/person223.json
+++ b/server/src/main/resources/sample_data/persons/person223.json
@@ -1,0 +1,28 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1943-10-22",
+  "email": "m.lange@gmail.de",
+  "firstName": "Martina",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "J589547387",
+  "lastName": "Lange",
+  "nationality": "deutsch",
+  "phoneNumber": "8877492424",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Abbendiekshof 61",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66540"
+}

--- a/server/src/main/resources/sample_data/persons/person224.json
+++ b/server/src/main/resources/sample_data/persons/person224.json
@@ -1,0 +1,28 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1965-10-05",
+  "email": "f.schulze@t-online.de",
+  "firstName": "Franz",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "D126763237",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "74523801055",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Aastwiete 47",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66782"
+}

--- a/server/src/main/resources/sample_data/persons/person225.json
+++ b/server/src/main/resources/sample_data/persons/person225.json
@@ -1,0 +1,29 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1987-10-24",
+  "email": "d.schroeder@web.de",
+  "firstName": "Daniela",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "K159091919",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "75170210814",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Aarhusweg 51",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66937"
+}

--- a/server/src/main/resources/sample_data/persons/person226.json
+++ b/server/src/main/resources/sample_data/persons/person226.json
@@ -1,0 +1,33 @@
+{
+  "city": "Saarlouis",
+  "coronaContacts": true,
+  "dateOfBirth": "1943-06-20",
+  "email": "k.winter@posteo.de",
+  "firstName": "Kai",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "R194058316",
+  "lastName": "Winter",
+  "nationality": "deutsch",
+  "phoneNumber": "98010562656",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Hauptstra\u00dfe 1",
+  "symptoms": [
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Schnupfen",
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66455"
+}

--- a/server/src/main/resources/sample_data/persons/person227.json
+++ b/server/src/main/resources/sample_data/persons/person227.json
@@ -1,0 +1,30 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1938-06-03",
+  "email": "f.schroeder@gmx.de",
+  "firstName": "Franz",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "J694710082",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "96106104628",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Waldstra\u00dfe 90",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66923"
+}

--- a/server/src/main/resources/sample_data/persons/person228.json
+++ b/server/src/main/resources/sample_data/persons/person228.json
@@ -1,0 +1,27 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": true,
+  "dateOfBirth": "1990-11-22",
+  "email": "k.schroeder@gmx.de",
+  "firstName": "Karl",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "I774305616",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "46271030147",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Haidth\u00f6heAarweg 76",
+  "symptoms": [
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66597"
+}

--- a/server/src/main/resources/sample_data/persons/person229.json
+++ b/server/src/main/resources/sample_data/persons/person229.json
@@ -1,0 +1,28 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "1965-08-29",
+  "email": "a.mueller@posteo.de",
+  "firstName": "Anna",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "Y774342024",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "25204561050",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Wintergasse 37",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "668101"
+}

--- a/server/src/main/resources/sample_data/persons/person23.json
+++ b/server/src/main/resources/sample_data/persons/person23.json
@@ -1,29 +1,30 @@
 {
-  "city": "K\u00f6ln",
-  "coronaContacts": false,
-  "dateOfBirth": "1952-10-20",
-  "email": "f.mueller@web.de",
-  "firstName": "Franz",
-  "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 79,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "V187174381",
-  "lastName": "M\u00fcller",
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1943-08-26",
+  "email": "d.klein@gmx.de",
+  "firstName": "Daniela",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "K477753674",
+  "lastName": "Klein",
   "nationality": "deutsch",
-  "phoneNumber": "9386774964",
+  "phoneNumber": "01436341095",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    ""
   ],
   "riskAreas": [
-    "Tirol"
+    "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Steinstra\u00dfe 70",
   "symptoms": [
+    "Atemschwierigkeiten",
+    "Schnupfen",
     "Fieber",
-    "Gelenkschmerzen"
+    "Husten"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "091310"
+  "zip": "66856"
 }

--- a/server/src/main/resources/sample_data/persons/person230.json
+++ b/server/src/main/resources/sample_data/persons/person230.json
@@ -1,0 +1,34 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": false,
+  "dateOfBirth": "1937-10-12",
+  "email": "e.winkler@t-online.de",
+  "firstName": "Emma",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "T840509085",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "2028457652",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Schernerweg 27",
+  "symptoms": [
+    "Fieber",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Husten",
+    "Atemschwierigkeiten",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66283"
+}

--- a/server/src/main/resources/sample_data/persons/person231.json
+++ b/server/src/main/resources/sample_data/persons/person231.json
@@ -1,0 +1,27 @@
+{
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": true,
+  "dateOfBirth": "1939-06-06",
+  "email": "c.schmitt@web.de",
+  "firstName": "Cornelius",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "Y563048450",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "4013223423",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "New York"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Aastwiete 10",
+  "symptoms": [
+    "Husten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66611"
+}

--- a/server/src/main/resources/sample_data/persons/person232.json
+++ b/server/src/main/resources/sample_data/persons/person232.json
@@ -1,0 +1,29 @@
+{
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1997-05-22",
+  "email": "l.bauer@t-online.de",
+  "firstName": "Lisa",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "F637552108",
+  "lastName": "Bauer",
+  "nationality": "deutsch",
+  "phoneNumber": "01193932105",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Aarhusweg 11",
+  "symptoms": [
+    "Fieber",
+    "Husten",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66249"
+}

--- a/server/src/main/resources/sample_data/persons/person233.json
+++ b/server/src/main/resources/sample_data/persons/person233.json
@@ -1,0 +1,27 @@
+{
+  "city": "Homburg",
+  "coronaContacts": false,
+  "dateOfBirth": "2005-12-04",
+  "email": "k.wagner@web.de",
+  "firstName": "Karl",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "N221166907",
+  "lastName": "Wagner",
+  "nationality": "deutsch",
+  "phoneNumber": "38759271012",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Nordtstra\u00dfe 45",
+  "symptoms": [
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66663"
+}

--- a/server/src/main/resources/sample_data/persons/person234.json
+++ b/server/src/main/resources/sample_data/persons/person234.json
@@ -1,0 +1,33 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "2000-02-11",
+  "email": "h.schroeder@web.de",
+  "firstName": "Hanna",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "V494537192",
+  "lastName": "Schr\u00f6der",
+  "nationality": "deutsch",
+  "phoneNumber": "71647941073",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Poststra\u00dfe 52",
+  "symptoms": [
+    "Fieber",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Husten",
+    "Kopfschmerzen",
+    "Schnupfen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66463"
+}

--- a/server/src/main/resources/sample_data/persons/person235.json
+++ b/server/src/main/resources/sample_data/persons/person235.json
@@ -1,0 +1,27 @@
+{
+  "city": "Bous",
+  "coronaContacts": false,
+  "dateOfBirth": "1962-04-20",
+  "email": "d.winkler@posteo.de",
+  "firstName": "Daniel",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "Q399456538",
+  "lastName": "Winkler",
+  "nationality": "deutsch",
+  "phoneNumber": "61367499410",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Z\u00e4hringerstra\u00dfe 45",
+  "symptoms": [
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "667109"
+}

--- a/server/src/main/resources/sample_data/persons/person236.json
+++ b/server/src/main/resources/sample_data/persons/person236.json
@@ -1,0 +1,33 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1997-08-22",
+  "email": "p.schulze@t-online.de",
+  "firstName": "Peter",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "Z600387133",
+  "lastName": "Schulze",
+  "nationality": "deutsch",
+  "phoneNumber": "02691052499",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Schernerweg 97",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Halschmerzen",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "661108"
+}

--- a/server/src/main/resources/sample_data/persons/person237.json
+++ b/server/src/main/resources/sample_data/persons/person237.json
@@ -1,0 +1,34 @@
+{
+  "city": "Kirkel",
+  "coronaContacts": true,
+  "dateOfBirth": "1957-08-15",
+  "email": "j.schmitt@gmail.de",
+  "firstName": "Jan",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "P808753985",
+  "lastName": "Schmitt",
+  "nationality": "deutsch",
+  "phoneNumber": "00281042762",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Wintergasse 91",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Husten",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66671"
+}

--- a/server/src/main/resources/sample_data/persons/person238.json
+++ b/server/src/main/resources/sample_data/persons/person238.json
@@ -1,0 +1,27 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": true,
+  "dateOfBirth": "1930-01-05",
+  "email": "m.mueller@t-online.de",
+  "firstName": "Marie",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "H795873638",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "55901056165",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Hauptstra\u00dfe 52",
+  "symptoms": [
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "665010"
+}

--- a/server/src/main/resources/sample_data/persons/person239.json
+++ b/server/src/main/resources/sample_data/persons/person239.json
@@ -1,0 +1,31 @@
+{
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1947-11-28",
+  "email": "p.lange@t-online.de",
+  "firstName": "Peter",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "D841809534",
+  "lastName": "Lange",
+  "nationality": "deutsch",
+  "phoneNumber": "6986407905",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Z\u00e4hringerstra\u00dfe 73",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Fieber"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66659"
+}

--- a/server/src/main/resources/sample_data/persons/person24.json
+++ b/server/src/main/resources/sample_data/persons/person24.json
@@ -1,31 +1,33 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": true,
-  "dateOfBirth": "1969-12-28",
-  "email": "j.schulze@gmail.de",
-  "firstName": "Jana",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 69,
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1970-12-19",
+  "email": "f.richter@gmx.de",
+  "firstName": "Franz",
+  "fluImmunization": true,
+  "gender": "male",
   "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "F951078441",
-  "lastName": "Schulze",
+  "insuranceMembershipNumber": "R413679331",
+  "lastName": "Richter",
   "nationality": "deutsch",
-  "phoneNumber": "7110341091036",
+  "phoneNumber": "8941343524",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    ""
   ],
   "riskAreas": [
-    "Tirol"
+    "Hubei"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Im KramersfeldAar\u00f6stra\u00dfe",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Aarhusweg 90",
   "symptoms": [
-    "Gelenkschmerzen",
+    "Fieber",
+    "Halschmerzen",
     "Husten",
-    "Erk\u00e4ltung",
-    "Schnupfen"
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "310242"
+  "weakenedImmuneSystem": false,
+  "zip": "66824"
 }

--- a/server/src/main/resources/sample_data/persons/person240.json
+++ b/server/src/main/resources/sample_data/persons/person240.json
@@ -1,0 +1,30 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": false,
+  "dateOfBirth": "1978-05-09",
+  "email": "j.schulz@web.de",
+  "firstName": "Jens",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "G472928235",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "0496391919",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "S\u00fcdweg 34",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66198"
+}

--- a/server/src/main/resources/sample_data/persons/person241.json
+++ b/server/src/main/resources/sample_data/persons/person241.json
@@ -1,0 +1,33 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1935-03-29",
+  "email": "m.berger@gmx.de",
+  "firstName": "Martina",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "B660782698",
+  "lastName": "Berger",
+  "nationality": "deutsch",
+  "phoneNumber": "010829731074",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Kronenstra\u00dfe 68",
+  "symptoms": [
+    "Schnupfen",
+    "Fieber",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66969"
+}

--- a/server/src/main/resources/sample_data/persons/person242.json
+++ b/server/src/main/resources/sample_data/persons/person242.json
@@ -1,0 +1,30 @@
+{
+  "city": "Bous",
+  "coronaContacts": true,
+  "dateOfBirth": "1969-11-06",
+  "email": "c.sommer@gmail.de",
+  "firstName": "Cornelius",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "U139732456",
+  "lastName": "Sommer",
+  "nationality": "deutsch",
+  "phoneNumber": "41093631230",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Abbendiekshof 39",
+  "symptoms": [
+    "Schnupfen",
+    "Husten",
+    "Gelenkschmerzen",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66778"
+}

--- a/server/src/main/resources/sample_data/persons/person243.json
+++ b/server/src/main/resources/sample_data/persons/person243.json
@@ -1,0 +1,27 @@
+{
+  "city": "Heusweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1995-06-20",
+  "email": "o.peters@t-online.de",
+  "firstName": "Olivia",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "Y663993780",
+  "lastName": "Peters",
+  "nationality": "deutsch",
+  "phoneNumber": "416510101623",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    ""
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Schernerweg 73",
+  "symptoms": [
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66818"
+}

--- a/server/src/main/resources/sample_data/persons/person244.json
+++ b/server/src/main/resources/sample_data/persons/person244.json
@@ -1,0 +1,28 @@
+{
+  "city": "Bous",
+  "coronaContacts": true,
+  "dateOfBirth": "1951-04-05",
+  "email": "i.winter@posteo.de",
+  "firstName": "Isabella",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "V364512739",
+  "lastName": "Winter",
+  "nationality": "deutsch",
+  "phoneNumber": "1234764907",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Poststra\u00dfe 47",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66158"
+}

--- a/server/src/main/resources/sample_data/persons/person245.json
+++ b/server/src/main/resources/sample_data/persons/person245.json
@@ -1,0 +1,33 @@
+{
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1975-05-18",
+  "email": "f.mueller@t-online.de",
+  "firstName": "Fin",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "J325900773",
+  "lastName": "M\u00fcller",
+  "nationality": "deutsch",
+  "phoneNumber": "641051018376",
+  "preIllnesses": [
+    "Herz-Kreislauf"
+  ],
+  "riskAreas": [
+    "Moscow"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Aarhusweg 50",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Husten",
+    "Fieber",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66441"
+}

--- a/server/src/main/resources/sample_data/persons/person246.json
+++ b/server/src/main/resources/sample_data/persons/person246.json
@@ -1,0 +1,25 @@
+{
+  "city": "Dudweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1951-02-27",
+  "email": "h.sommer@gmail.de",
+  "firstName": "Hanna",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "O949350526",
+  "lastName": "Sommer",
+  "nationality": "deutsch",
+  "phoneNumber": "2481569857",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Rosenstra\u00dfe 3",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "6601010"
+}

--- a/server/src/main/resources/sample_data/persons/person247.json
+++ b/server/src/main/resources/sample_data/persons/person247.json
@@ -1,0 +1,32 @@
+{
+  "city": "St. Ingbert",
+  "coronaContacts": true,
+  "dateOfBirth": "1985-04-17",
+  "email": "m.schulz@t-online.de",
+  "firstName": "Martina",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "N494707031",
+  "lastName": "Schulz",
+  "nationality": "deutsch",
+  "phoneNumber": "102910657724",
+  "preIllnesses": [
+    "Imunsystemschw\u00e4che"
+  ],
+  "riskAreas": [
+    "Tirol"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Abbachstra\u00dfe 87",
+  "symptoms": [
+    "Erk\u00e4ltung",
+    "Husten",
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66954"
+}

--- a/server/src/main/resources/sample_data/persons/person248.json
+++ b/server/src/main/resources/sample_data/persons/person248.json
@@ -1,0 +1,30 @@
+{
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1951-10-09",
+  "email": "p.winter@web.de",
+  "firstName": "Peter",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "G973394943",
+  "lastName": "Winter",
+  "nationality": "deutsch",
+  "phoneNumber": "2152910867",
+  "preIllnesses": [
+    "Krebserkrankung"
+  ],
+  "riskAreas": [
+    "GrandEst"
+  ],
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Nordtstra\u00dfe 86",
+  "symptoms": [
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Fieber",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66713"
+}

--- a/server/src/main/resources/sample_data/persons/person249.json
+++ b/server/src/main/resources/sample_data/persons/person249.json
@@ -1,0 +1,29 @@
+{
+  "city": "Neunkirchen",
+  "coronaContacts": true,
+  "dateOfBirth": "1982-07-26",
+  "email": "h.richter@gmx.de",
+  "firstName": "Hanna",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "K844128379",
+  "lastName": "Richter",
+  "nationality": "deutsch",
+  "phoneNumber": "2044397359",
+  "preIllnesses": [
+    ""
+  ],
+  "riskAreas": [
+    "Madrid"
+  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Bismarckstra\u00dfe 82",
+  "symptoms": [
+    "Halschmerzen",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66710"
+}

--- a/server/src/main/resources/sample_data/persons/person25.json
+++ b/server/src/main/resources/sample_data/persons/person25.json
@@ -1,34 +1,33 @@
 {
-  "city": "Bochum",
+  "city": "Kirkel",
   "coronaContacts": true,
-  "dateOfBirth": "2000-07-24",
-  "email": "d.mueller@web.de",
-  "firstName": "Daniela",
-  "fluImmunization": false,
+  "dateOfBirth": "1997-07-16",
+  "email": "i.schmidt@t-online.de",
+  "firstName": "Isabella",
+  "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 34,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "F728492896",
-  "lastName": "M\u00fcller",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "H932894596",
+  "lastName": "Schmidt",
   "nationality": "deutsch",
-  "phoneNumber": "59401310990",
+  "phoneNumber": "191010022941",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "GrandEst"
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordtstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Abbendiekshof 15",
   "symptoms": [
-    "Fieber",
-    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
     "Schnupfen",
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
     "Halschmerzen",
     "Kopfschmerzen",
-    "Gelenkschmerzen",
     "Husten"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "90278"
+  "zip": "66869"
 }

--- a/server/src/main/resources/sample_data/persons/person26.json
+++ b/server/src/main/resources/sample_data/persons/person26.json
@@ -1,31 +1,29 @@
 {
-  "city": "Bochum",
+  "city": "Heusweiler",
   "coronaContacts": false,
-  "dateOfBirth": "1935-01-15",
-  "email": "p.lange@gmx.de",
-  "firstName": "Petra",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 52,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "O916033628",
-  "lastName": "Lange",
+  "dateOfBirth": "1975-03-18",
+  "email": "k.schulz@posteo.de",
+  "firstName": "Karl",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "I945923902",
+  "lastName": "Schulz",
   "nationality": "deutsch",
-  "phoneNumber": "15451680108",
+  "phoneNumber": "1206797403",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    ""
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Abbendiekshof",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Wintergasse 90",
   "symptoms": [
-    "Schnupfen",
-    "Gelenkschmerzen",
-    "Erk\u00e4ltung",
-    "Kopfschmerzen"
+    "Halschmerzen",
+    "Husten",
+    "Atemschwierigkeiten"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "03859"
+  "weakenedImmuneSystem": false,
+  "zip": "66471"
 }

--- a/server/src/main/resources/sample_data/persons/person27.json
+++ b/server/src/main/resources/sample_data/persons/person27.json
@@ -1,28 +1,27 @@
 {
-  "city": "Freiburg",
+  "city": "Bous",
   "coronaContacts": true,
-  "dateOfBirth": "1935-07-03",
-  "email": "k.bauer@t-online.de",
-  "firstName": "Karl",
-  "fluImmunization": true,
+  "dateOfBirth": "1966-10-24",
+  "email": "d.mueller@posteo.de",
+  "firstName": "Daniel",
+  "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 61,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "T645719501",
-  "lastName": "Bauer",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "K748232591",
+  "lastName": "M\u00fcller",
   "nationality": "deutsch",
-  "phoneNumber": "31711027484",
+  "phoneNumber": "9471746488",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    ""
   ],
   "riskAreas": [
-    "Tirol"
+    "New York"
   ],
   "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Niekampsweg",
+  "street": "Steinstra\u00dfe 56",
   "symptoms": [
-    "Atemschwierigkeiten"
+    "Erk\u00e4ltung"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "73782"
+  "weakenedImmuneSystem": true,
+  "zip": "66190"
 }

--- a/server/src/main/resources/sample_data/persons/person28.json
+++ b/server/src/main/resources/sample_data/persons/person28.json
@@ -1,33 +1,32 @@
 {
-  "city": "Freiburg",
+  "city": "Dudweiler",
   "coronaContacts": false,
-  "dateOfBirth": "1930-10-22",
-  "email": "k.winkler@gmail.de",
-  "firstName": "Karl",
+  "dateOfBirth": "1945-09-21",
+  "email": "m.mueller@posteo.de",
+  "firstName": "Martina",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 41,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "K899621068",
-  "lastName": "Winkler",
+  "gender": "female",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "N844826434",
+  "lastName": "M\u00fcller",
   "nationality": "deutsch",
-  "phoneNumber": "7278755886",
+  "phoneNumber": "74296107175",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    ""
   ],
   "riskAreas": [
-    "Madrid"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Abbendiekshof",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Kaiserstra\u00dfe 42",
   "symptoms": [
-    "Halschmerzen",
-    "Kopfschmerzen",
-    "Gelenkschmerzen",
-    "Fieber",
+    "Husten",
     "Erk\u00e4ltung",
-    "Husten"
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Atemschwierigkeiten",
+    "Fieber"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "33963"
+  "weakenedImmuneSystem": false,
+  "zip": "665101"
 }

--- a/server/src/main/resources/sample_data/persons/person29.json
+++ b/server/src/main/resources/sample_data/persons/person29.json
@@ -1,31 +1,25 @@
 {
-  "city": "Bochum",
+  "city": "Kirkel",
   "coronaContacts": true,
-  "dateOfBirth": "1947-01-24",
-  "email": "j.mueller@web.de",
-  "firstName": "Jens",
+  "dateOfBirth": "1939-06-20",
+  "email": "s.mueller@posteo.de",
+  "firstName": "Susanne",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 10,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "B762992051",
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "W270057261",
   "lastName": "M\u00fcller",
   "nationality": "deutsch",
-  "phoneNumber": "26102174596",
+  "phoneNumber": "71070348247",
   "preIllnesses": [
-    ""
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    ""
+    "Tirol"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordtstra\u00dfe",
-  "symptoms": [
-    "Erk\u00e4ltung",
-    "Kopfschmerzen",
-    "Husten",
-    "Gelenkschmerzen"
-  ],
-  "weakenedImmuneSystem": true,
-  "zip": "510865"
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Rosenstra\u00dfe 62",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "661010"
 }

--- a/server/src/main/resources/sample_data/persons/person3.json
+++ b/server/src/main/resources/sample_data/persons/person3.json
@@ -1,34 +1,32 @@
 {
-  "city": "Freiburg",
+  "city": "P\u00fcttlingen",
   "coronaContacts": false,
-  "dateOfBirth": "1974-12-18",
-  "email": "a.weber@posteo.de",
-  "firstName": "Anna",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 11,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "C513140753",
-  "lastName": "Weber",
+  "dateOfBirth": "1947-03-09",
+  "email": "f.schmidt@gmx.de",
+  "firstName": "Fin",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "D264112119",
+  "lastName": "Schmidt",
   "nationality": "deutsch",
-  "phoneNumber": "8496965328",
+  "phoneNumber": "2388496965",
   "preIllnesses": [
-    "Krebserkrankung"
+    ""
   ],
   "riskAreas": [
-    "Hubei"
+    "Madrid"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Abbendiekshof",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Abbendiekshof 17",
   "symptoms": [
-    "Atemschwierigkeiten",
-    "Gelenkschmerzen",
-    "Husten",
-    "Kopfschmerzen",
-    "Schnupfen",
+    "Fieber",
     "Erk\u00e4ltung",
-    "Fieber"
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Kopfschmerzen",
+    "Schnupfen"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "012102"
+  "weakenedImmuneSystem": true,
+  "zip": "66871"
 }

--- a/server/src/main/resources/sample_data/persons/person30.json
+++ b/server/src/main/resources/sample_data/persons/person30.json
@@ -1,31 +1,25 @@
 {
-  "city": "K\u00f6ln",
-  "coronaContacts": true,
-  "dateOfBirth": "2002-01-11",
-  "email": "a.winkler@gmail.de",
-  "firstName": "Anna",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 23,
+  "city": "Saarlouis",
+  "coronaContacts": false,
+  "dateOfBirth": "1942-12-10",
+  "email": "j.schulze@posteo.de",
+  "firstName": "Jens",
+  "fluImmunization": true,
+  "gender": "male",
   "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "S253671484",
-  "lastName": "Winkler",
+  "insuranceMembershipNumber": "K945805127",
+  "lastName": "Schulze",
   "nationality": "deutsch",
-  "phoneNumber": "0455623869",
+  "phoneNumber": "8467737826",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Tirol"
+    "New York"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Nordtstra\u00dfe",
-  "symptoms": [
-    "Gelenkschmerzen",
-    "Schnupfen",
-    "Kopfschmerzen",
-    "Husten"
-  ],
-  "weakenedImmuneSystem": true,
-  "zip": "22196"
+  "street": "Niekampsweg 76",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "66821"
 }

--- a/server/src/main/resources/sample_data/persons/person31.json
+++ b/server/src/main/resources/sample_data/persons/person31.json
@@ -1,26 +1,28 @@
 {
-  "city": "Freiburg",
-  "coronaContacts": true,
-  "dateOfBirth": "1930-05-21",
-  "email": "d.klein@gmail.de",
-  "firstName": "Daniel",
+  "city": "Heusweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1963-09-25",
+  "email": "j.schmidt@gmail.de",
+  "firstName": "Jens",
   "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 45,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "A707661655",
-  "lastName": "Klein",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "E631855083",
+  "lastName": "Schmidt",
   "nationality": "deutsch",
-  "phoneNumber": "6474367136",
+  "phoneNumber": "8675339636",
   "preIllnesses": [
     "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Madrid"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordstra\u00dfe",
-  "symptoms": [],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Im KramersfeldAar\u00f6stra\u00dfe 40",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Halschmerzen"
+  ],
   "weakenedImmuneSystem": true,
-  "zip": "944010"
+  "zip": "66766"
 }

--- a/server/src/main/resources/sample_data/persons/person32.json
+++ b/server/src/main/resources/sample_data/persons/person32.json
@@ -1,30 +1,25 @@
 {
-  "city": "M\u00fcnchen",
+  "city": "V\u00f6lklingen",
   "coronaContacts": true,
-  "dateOfBirth": "1977-11-07",
-  "email": "a.schroeder@gmail.de",
-  "firstName": "Annika",
+  "dateOfBirth": "1987-07-28",
+  "email": "k.schmitt@t-online.de",
+  "firstName": "Kai",
   "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 39,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "K902601465",
-  "lastName": "Schr\u00f6der",
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "W915401487",
+  "lastName": "Schmitt",
   "nationality": "deutsch",
-  "phoneNumber": "9410101021011010",
+  "phoneNumber": "102174596101",
   "preIllnesses": [
     "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Hubei"
+    ""
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Aarhusweg",
-  "symptoms": [
-    "Schnupfen",
-    "Halschmerzen",
-    "Atemschwierigkeiten"
-  ],
-  "weakenedImmuneSystem": true,
-  "zip": "70952"
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordufer 42",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "661086"
 }

--- a/server/src/main/resources/sample_data/persons/person33.json
+++ b/server/src/main/resources/sample_data/persons/person33.json
@@ -1,28 +1,28 @@
 {
-  "city": "D\u00fcsseldorf",
-  "coronaContacts": false,
-  "dateOfBirth": "1962-02-15",
-  "email": "k.klein@gmail.de",
-  "firstName": "Karl",
-  "fluImmunization": true,
+  "city": "Bous",
+  "coronaContacts": true,
+  "dateOfBirth": "1993-11-23",
+  "email": "m.schulz@gmx.de",
+  "firstName": "Matthias",
+  "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 33,
   "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "M983063850",
-  "lastName": "Klein",
+  "insuranceMembershipNumber": "V950961305",
+  "lastName": "Schulz",
   "nationality": "deutsch",
-  "phoneNumber": "123101068516",
+  "phoneNumber": "1724005045",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    ""
+    "Tirol"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Aarhusweg",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hauptstra\u00dfe 55",
   "symptoms": [
-    "Erk\u00e4ltung"
+    "Fieber",
+    "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "817510"
+  "zip": "66238"
 }

--- a/server/src/main/resources/sample_data/persons/person34.json
+++ b/server/src/main/resources/sample_data/persons/person34.json
@@ -1,17 +1,16 @@
 {
-  "city": "Hamburg",
+  "city": "Bous",
   "coronaContacts": false,
-  "dateOfBirth": "1967-11-14",
-  "email": "d.lange@gmx.de",
-  "firstName": "Daniel",
+  "dateOfBirth": "1946-11-09",
+  "email": "m.weber@posteo.de",
+  "firstName": "Martina",
   "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 49,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "U206323670",
-  "lastName": "Lange",
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "I590523712",
+  "lastName": "Weber",
   "nationality": "deutsch",
-  "phoneNumber": "1200471138",
+  "phoneNumber": "741007410821",
   "preIllnesses": [
     "Imunsystemschw\u00e4che"
   ],
@@ -19,15 +18,12 @@
     "GrandEst"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Haidth\u00f6heAarweg",
+  "street": "Waldstra\u00dfe 44",
   "symptoms": [
-    "Atemschwierigkeiten",
-    "Husten",
-    "Kopfschmerzen",
-    "Schnupfen",
-    "Fieber",
+    "Halschmerzen",
+    "Gelenkschmerzen",
     "Erk\u00e4ltung"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "751086"
+  "weakenedImmuneSystem": false,
+  "zip": "669410"
 }

--- a/server/src/main/resources/sample_data/persons/person35.json
+++ b/server/src/main/resources/sample_data/persons/person35.json
@@ -1,32 +1,27 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": true,
-  "dateOfBirth": "1998-07-09",
-  "email": "t.bauer@gmail.de",
-  "firstName": "Tim",
-  "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 100,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "G729624046",
-  "lastName": "Bauer",
+  "city": "P\u00fcttlingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1955-05-01",
+  "email": "h.schroeder@t-online.de",
+  "firstName": "Hanna",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "Y807790785",
+  "lastName": "Schr\u00f6der",
   "nationality": "deutsch",
-  "phoneNumber": "3171103101090",
+  "phoneNumber": "91009743953",
   "preIllnesses": [
-    "Krebserkrankung"
+    ""
   ],
   "riskAreas": [
-    "GrandEst"
+    "Moscow"
   ],
   "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Aarhusweg",
+  "street": "Kronenstra\u00dfe 24",
   "symptoms": [
-    "Schnupfen",
-    "Halschmerzen",
-    "Atemschwierigkeiten",
-    "Husten",
-    "Gelenkschmerzen"
+    "Husten"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "53293"
+  "weakenedImmuneSystem": false,
+  "zip": "669410"
 }

--- a/server/src/main/resources/sample_data/persons/person36.json
+++ b/server/src/main/resources/sample_data/persons/person36.json
@@ -1,26 +1,32 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": true,
-  "dateOfBirth": "1989-01-12",
-  "email": "a.mueller@t-online.de",
-  "firstName": "Anna",
+  "city": "Neunkirchen",
+  "coronaContacts": false,
+  "dateOfBirth": "1968-06-24",
+  "email": "h.weber@t-online.de",
+  "firstName": "Hanna",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 95,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "Q337887233",
-  "lastName": "M\u00fcller",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "E909763993",
+  "lastName": "Weber",
   "nationality": "deutsch",
-  "phoneNumber": "3950240268",
+  "phoneNumber": "6232858842",
   "preIllnesses": [
     "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "New York"
+    "Tirol"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Im KramersfeldAar\u00f6stra\u00dfe",
-  "symptoms": [],
-  "weakenedImmuneSystem": true,
-  "zip": "17758"
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Sonnenweg 61",
+  "symptoms": [
+    "Kopfschmerzen",
+    "Husten",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Schnupfen",
+    "Gelenkschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66451"
 }

--- a/server/src/main/resources/sample_data/persons/person37.json
+++ b/server/src/main/resources/sample_data/persons/person37.json
@@ -1,28 +1,34 @@
 {
-  "city": "Frankfurt",
+  "city": "Saarbr\u00fccken",
   "coronaContacts": true,
-  "dateOfBirth": "1954-07-22",
-  "email": "j.peters@gmx.de",
-  "firstName": "Jana",
-  "fluImmunization": true,
+  "dateOfBirth": "1976-08-01",
+  "email": "i.winkler@t-online.de",
+  "firstName": "Isabella",
+  "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 79,
   "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "O642831335",
-  "lastName": "Peters",
+  "insuranceMembershipNumber": "P224683417",
+  "lastName": "Winkler",
   "nationality": "deutsch",
-  "phoneNumber": "1771159212",
+  "phoneNumber": "985931011074",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "New York"
+    ""
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Aastwiete",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Kronenstra\u00dfe 52",
   "symptoms": [
+    "Schnupfen",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten",
+    "Husten",
     "Fieber"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "109856"
+  "zip": "66120"
 }

--- a/server/src/main/resources/sample_data/persons/person38.json
+++ b/server/src/main/resources/sample_data/persons/person38.json
@@ -1,35 +1,25 @@
 {
-  "city": "Kiel",
+  "city": "Heusweiler",
   "coronaContacts": true,
-  "dateOfBirth": "1962-08-13",
-  "email": "d.schulze@gmx.de",
-  "firstName": "Daniela",
+  "dateOfBirth": "1978-08-15",
+  "email": "p.mueller@gmail.de",
+  "firstName": "Petra",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 8,
   "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "R164404084",
-  "lastName": "Schulze",
+  "insuranceMembershipNumber": "U786650291",
+  "lastName": "M\u00fcller",
   "nationality": "deutsch",
-  "phoneNumber": "615651045210",
+  "phoneNumber": "351105810506",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Krebserkrankung"
   ],
   "riskAreas": [
     "Hubei"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Abbendiekshof",
-  "symptoms": [
-    "Kopfschmerzen",
-    "Gelenkschmerzen",
-    "Husten",
-    "Erk\u00e4ltung",
-    "Schnupfen",
-    "Atemschwierigkeiten",
-    "Fieber",
-    "Halschmerzen"
-  ],
-  "weakenedImmuneSystem": true,
-  "zip": "11161"
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Sonnenweg 24",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "66171"
 }

--- a/server/src/main/resources/sample_data/persons/person39.json
+++ b/server/src/main/resources/sample_data/persons/person39.json
@@ -1,26 +1,30 @@
 {
-  "city": "Berlin",
-  "coronaContacts": false,
-  "dateOfBirth": "1978-03-22",
-  "email": "l.schroeder@web.de",
-  "firstName": "Lisa",
-  "fluImmunization": true,
-  "gender": "female",
-  "houseNumber": 71,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "V990626742",
-  "lastName": "Schr\u00f6der",
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1978-04-11",
+  "email": "d.richter@web.de",
+  "firstName": "Daniel",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "S447646966",
+  "lastName": "Richter",
   "nationality": "deutsch",
-  "phoneNumber": "7315851493",
+  "phoneNumber": "2904228421",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    ""
   ],
   "riskAreas": [
-    "Hubei"
+    ""
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Niekampsweg",
-  "symptoms": [],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Bismarckstra\u00dfe 3",
+  "symptoms": [
+    "Husten",
+    "Fieber",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung"
+  ],
   "weakenedImmuneSystem": true,
-  "zip": "9910108"
+  "zip": "66205"
 }

--- a/server/src/main/resources/sample_data/persons/person4.json
+++ b/server/src/main/resources/sample_data/persons/person4.json
@@ -1,30 +1,25 @@
 {
-  "city": "Berlin",
+  "city": "Dudweiler",
   "coronaContacts": true,
-  "dateOfBirth": "1941-03-17",
-  "email": "j.winkler@gmail.de",
-  "firstName": "Jana",
+  "dateOfBirth": "1991-05-14",
+  "email": "f.bauer@gmail.de",
+  "firstName": "Fin",
   "fluImmunization": true,
-  "gender": "female",
-  "houseNumber": 99,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "L992994062",
-  "lastName": "Winkler",
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "Y273461957",
+  "lastName": "Bauer",
   "nationality": "deutsch",
-  "phoneNumber": "110410893252",
+  "phoneNumber": "27048281104",
   "preIllnesses": [
-    "Herz-Kreislauf"
-  ],
-  "riskAreas": [
     ""
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "B\u00fcckerheide",
-  "symptoms": [
-    "Husten",
-    "Fieber",
-    "Atemschwierigkeiten"
+  "riskAreas": [
+    "Hubei"
   ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Nordtstra\u00dfe 81",
+  "symptoms": [],
   "weakenedImmuneSystem": false,
-  "zip": "80957"
+  "zip": "66893"
 }

--- a/server/src/main/resources/sample_data/persons/person40.json
+++ b/server/src/main/resources/sample_data/persons/person40.json
@@ -1,26 +1,31 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": true,
-  "dateOfBirth": "1987-10-22",
-  "email": "m.peters@posteo.de",
-  "firstName": "Marie",
-  "fluImmunization": true,
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "1930-02-15",
+  "email": "d.winkler@web.de",
+  "firstName": "Daniela",
+  "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 43,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "E269017588",
-  "lastName": "Peters",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "W576271425",
+  "lastName": "Winkler",
   "nationality": "deutsch",
-  "phoneNumber": "61210018366",
+  "phoneNumber": "839010847100",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    ""
+    "Madrid"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Abbendiekshof",
-  "symptoms": [],
-  "weakenedImmuneSystem": false,
-  "zip": "25459"
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Im KramersfeldAar\u00f6stra\u00dfe 61",
+  "symptoms": [
+    "Schnupfen",
+    "Husten",
+    "Fieber",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "666610"
 }

--- a/server/src/main/resources/sample_data/persons/person41.json
+++ b/server/src/main/resources/sample_data/persons/person41.json
@@ -1,29 +1,27 @@
 {
-  "city": "Berlin",
-  "coronaContacts": false,
-  "dateOfBirth": "1952-05-07",
-  "email": "d.schroeder@gmx.de",
-  "firstName": "Daniela",
+  "city": "Heusweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1991-11-21",
+  "email": "p.sommer@t-online.de",
+  "firstName": "Petra",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 85,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "G423646570",
-  "lastName": "Schr\u00f6der",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "L263894795",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "815614101097",
+  "phoneNumber": "8367365766",
   "preIllnesses": [
     "Herz-Kreislauf"
   ],
   "riskAreas": [
     ""
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "B\u00fcckerheide",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Tulpenweg 12",
   "symptoms": [
-    "Atemschwierigkeiten",
-    "Schnupfen"
+    "Fieber"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "40369"
+  "zip": "66565"
 }

--- a/server/src/main/resources/sample_data/persons/person42.json
+++ b/server/src/main/resources/sample_data/persons/person42.json
@@ -1,29 +1,29 @@
 {
-  "city": "Freiburg",
-  "coronaContacts": true,
-  "dateOfBirth": "1937-12-08",
-  "email": "a.schulz@gmx.de",
-  "firstName": "Anna",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 40,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "D534900128",
-  "lastName": "Schulz",
+  "city": "Kirkel",
+  "coronaContacts": false,
+  "dateOfBirth": "1934-01-19",
+  "email": "m.winkler@posteo.de",
+  "firstName": "Matthias",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "G266140258",
+  "lastName": "Winkler",
   "nationality": "deutsch",
-  "phoneNumber": "88105160607",
+  "phoneNumber": "885101651060",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Hubei"
+    ""
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Im KramersfeldAar\u00f6stra\u00dfe",
+  "street": "Wintergasse 76",
   "symptoms": [
-    "Gelenkschmerzen",
-    "Halschmerzen"
+    "Fieber",
+    "Schnupfen",
+    "Atemschwierigkeiten"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "969610"
+  "weakenedImmuneSystem": true,
+  "zip": "66451"
 }

--- a/server/src/main/resources/sample_data/persons/person43.json
+++ b/server/src/main/resources/sample_data/persons/person43.json
@@ -1,29 +1,25 @@
 {
-  "city": "K\u00f6ln",
-  "coronaContacts": true,
-  "dateOfBirth": "1954-09-03",
-  "email": "f.richter@web.de",
-  "firstName": "Franz",
+  "city": "Kirkel",
+  "coronaContacts": false,
+  "dateOfBirth": "1926-10-22",
+  "email": "c.sommer@web.de",
+  "firstName": "Christopher",
   "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 65,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "E374843786",
-  "lastName": "Richter",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "M174716780",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "64535218101",
+  "phoneNumber": "108091040244",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
     "New York"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "B\u00fcckerheide",
-  "symptoms": [
-    "Fieber",
-    "Gelenkschmerzen"
-  ],
-  "weakenedImmuneSystem": false,
-  "zip": "355102"
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "S\u00fcdweg 44",
+  "symptoms": [],
+  "weakenedImmuneSystem": true,
+  "zip": "66022"
 }

--- a/server/src/main/resources/sample_data/persons/person44.json
+++ b/server/src/main/resources/sample_data/persons/person44.json
@@ -1,33 +1,34 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": true,
-  "dateOfBirth": "1986-08-03",
-  "email": "m.lange@gmail.de",
-  "firstName": "Marie",
-  "fluImmunization": true,
+  "city": "Neunkirchen",
+  "coronaContacts": false,
+  "dateOfBirth": "1985-06-10",
+  "email": "s.schmitt@gmail.de",
+  "firstName": "Susanne",
+  "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 59,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "C760360225",
-  "lastName": "Lange",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "O544726404",
+  "lastName": "Schmitt",
   "nationality": "deutsch",
-  "phoneNumber": "77104490581",
+  "phoneNumber": "59910229010",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    ""
   ],
   "riskAreas": [
     "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Aastwiete",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Haidth\u00f6heAarweg 34",
   "symptoms": [
-    "Gelenkschmerzen",
-    "Atemschwierigkeiten",
-    "Halschmerzen",
-    "Husten",
+    "Fieber",
+    "Schnupfen",
     "Erk\u00e4ltung",
-    "Schnupfen"
+    "Husten",
+    "Halschmerzen",
+    "Kopfschmerzen",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "70054"
+  "zip": "667106"
 }

--- a/server/src/main/resources/sample_data/persons/person45.json
+++ b/server/src/main/resources/sample_data/persons/person45.json
@@ -1,28 +1,27 @@
 {
-  "city": "Berlin",
-  "coronaContacts": false,
-  "dateOfBirth": "1962-12-03",
-  "email": "p.klein@t-online.de",
-  "firstName": "Peter",
+  "city": "Bous",
+  "coronaContacts": true,
+  "dateOfBirth": "1988-05-10",
+  "email": "f.schroeder@posteo.de",
+  "firstName": "Franz",
   "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 46,
   "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "U459327003",
-  "lastName": "Klein",
+  "insuranceMembershipNumber": "B568387228",
+  "lastName": "Schr\u00f6der",
   "nationality": "deutsch",
-  "phoneNumber": "81020377889",
+  "phoneNumber": "5107622683",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Hubei"
+    "Tirol"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Haidth\u00f6heAarweg",
+  "street": "Hafenstra\u00dfe 71",
   "symptoms": [
-    "Halschmerzen"
+    "Kopfschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "54665"
+  "zip": "661051"
 }

--- a/server/src/main/resources/sample_data/persons/person46.json
+++ b/server/src/main/resources/sample_data/persons/person46.json
@@ -1,29 +1,27 @@
 {
-  "city": "Freiburg",
+  "city": "St. Ingbert",
   "coronaContacts": true,
-  "dateOfBirth": "1961-05-31",
-  "email": "l.schroeder@posteo.de",
-  "firstName": "Lisa",
+  "dateOfBirth": "2003-06-06",
+  "email": "p.schulze@gmx.de",
+  "firstName": "Petra",
   "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 16,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "L119574893",
-  "lastName": "Schr\u00f6der",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "Y280531127",
+  "lastName": "Schulze",
   "nationality": "deutsch",
-  "phoneNumber": "1010629148610",
+  "phoneNumber": "9751613696",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Tirol"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Abbachstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Hafenstra\u00dfe 10",
   "symptoms": [
-    "Erk\u00e4ltung",
-    "Schnupfen"
+    "Erk\u00e4ltung"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "10108110"
+  "zip": "66645"
 }

--- a/server/src/main/resources/sample_data/persons/person47.json
+++ b/server/src/main/resources/sample_data/persons/person47.json
@@ -1,31 +1,27 @@
 {
-  "city": "Kiel",
+  "city": "Kirkel",
   "coronaContacts": false,
-  "dateOfBirth": "1993-09-25",
-  "email": "h.mueller@gmail.de",
-  "firstName": "Hans",
-  "fluImmunization": true,
+  "dateOfBirth": "1973-04-06",
+  "email": "f.schulze@posteo.de",
+  "firstName": "Franz",
+  "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 23,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "X355046107",
-  "lastName": "M\u00fcller",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "U439451556",
+  "lastName": "Schulze",
   "nationality": "deutsch",
-  "phoneNumber": "88010592962",
+  "phoneNumber": "921012107799",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Tirol"
+    "New York"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Haidth\u00f6heAarweg",
+  "street": "Waldstra\u00dfe 87",
   "symptoms": [
-    "Gelenkschmerzen",
-    "Fieber",
-    "Atemschwierigkeiten",
-    "Halschmerzen"
+    "Gelenkschmerzen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "92706"
+  "weakenedImmuneSystem": false,
+  "zip": "6691010"
 }

--- a/server/src/main/resources/sample_data/persons/person48.json
+++ b/server/src/main/resources/sample_data/persons/person48.json
@@ -1,28 +1,33 @@
 {
-  "city": "D\u00fcsseldorf",
+  "city": "Neunkirchen",
   "coronaContacts": true,
-  "dateOfBirth": "1957-09-17",
-  "email": "d.klein@gmail.de",
-  "firstName": "Daniela",
-  "fluImmunization": true,
-  "gender": "female",
-  "houseNumber": 13,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "Q258214411",
-  "lastName": "Klein",
+  "dateOfBirth": "1966-08-15",
+  "email": "t.berger@t-online.de",
+  "firstName": "Tim",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "U302120588",
+  "lastName": "Berger",
   "nationality": "deutsch",
-  "phoneNumber": "62392401075",
+  "phoneNumber": "00541101998",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    ""
   ],
   "riskAreas": [
-    "Tirol"
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "B\u00fcckerheide",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Z\u00e4hringerstra\u00dfe 59",
   "symptoms": [
-    "Erk\u00e4ltung"
+    "Schnupfen",
+    "Husten",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "81412"
+  "weakenedImmuneSystem": false,
+  "zip": "66980"
 }

--- a/server/src/main/resources/sample_data/persons/person49.json
+++ b/server/src/main/resources/sample_data/persons/person49.json
@@ -1,35 +1,30 @@
 {
-  "city": "Berlin",
-  "coronaContacts": false,
-  "dateOfBirth": "1941-06-08",
-  "email": "j.peters@gmx.de",
-  "firstName": "Jan",
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1938-09-20",
+  "email": "m.schmitt@gmx.de",
+  "firstName": "Matthias",
   "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 4,
   "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "A374796224",
-  "lastName": "Peters",
+  "insuranceMembershipNumber": "R828404274",
+  "lastName": "Schmitt",
   "nationality": "deutsch",
-  "phoneNumber": "61530511052",
+  "phoneNumber": "25546651090",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "New York"
+    "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Haidth\u00f6heAarweg",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Nordstra\u00dfe 80",
   "symptoms": [
-    "Halschmerzen",
-    "Husten",
     "Schnupfen",
-    "Fieber",
-    "Kopfschmerzen",
     "Gelenkschmerzen",
-    "Erk\u00e4ltung",
+    "Husten",
     "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "47277"
+  "zip": "661051"
 }

--- a/server/src/main/resources/sample_data/persons/person5.json
+++ b/server/src/main/resources/sample_data/persons/person5.json
@@ -1,35 +1,29 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": false,
-  "dateOfBirth": "1989-11-16",
-  "email": "k.winter@posteo.de",
-  "firstName": "Kai",
-  "fluImmunization": false,
+  "city": "Bous",
+  "coronaContacts": true,
+  "dateOfBirth": "1975-01-08",
+  "email": "k.winkler@gmail.de",
+  "firstName": "Konrad",
+  "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 85,
   "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "H168747287",
-  "lastName": "Winter",
+  "insuranceMembershipNumber": "R910959828",
+  "lastName": "Winkler",
   "nationality": "deutsch",
-  "phoneNumber": "8248963834",
+  "phoneNumber": "91171822107",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    ""
+    "Hubei"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Niekampsweg",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Poststra\u00dfe 21",
   "symptoms": [
-    "Erk\u00e4ltung",
     "Atemschwierigkeiten",
-    "Fieber",
-    "Husten",
-    "Halschmerzen",
-    "Schnupfen",
-    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
     "Kopfschmerzen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "105787"
+  "weakenedImmuneSystem": false,
+  "zip": "66489"
 }

--- a/server/src/main/resources/sample_data/persons/person50.json
+++ b/server/src/main/resources/sample_data/persons/person50.json
@@ -1,35 +1,31 @@
 {
-  "city": "Kiel",
+  "city": "V\u00f6lklingen",
   "coronaContacts": false,
-  "dateOfBirth": "1937-01-21",
-  "email": "d.klein@web.de",
-  "firstName": "Daniel",
-  "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 53,
+  "dateOfBirth": "1929-12-31",
+  "email": "e.winter@posteo.de",
+  "firstName": "Emma",
+  "fluImmunization": false,
+  "gender": "female",
   "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "Q684203557",
-  "lastName": "Klein",
+  "insuranceMembershipNumber": "L431642423",
+  "lastName": "Winter",
   "nationality": "deutsch",
-  "phoneNumber": "8932460953",
+  "phoneNumber": "1486105210108",
   "preIllnesses": [
-    "Krebserkrankung"
-  ],
-  "riskAreas": [
     ""
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordstra\u00dfe",
+  "riskAreas": [
+    "Hubei"
+  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Haidth\u00f6heAarweg 82",
   "symptoms": [
-    "Husten",
-    "Erk\u00e4ltung",
-    "Halschmerzen",
     "Gelenkschmerzen",
-    "Kopfschmerzen",
     "Fieber",
-    "Schnupfen",
+    "Halschmerzen",
+    "Kopfschmerzen",
     "Atemschwierigkeiten"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "2101018"
+  "weakenedImmuneSystem": true,
+  "zip": "661068"
 }

--- a/server/src/main/resources/sample_data/persons/person51.json
+++ b/server/src/main/resources/sample_data/persons/person51.json
@@ -1,31 +1,29 @@
 {
-  "city": "D\u00fcsseldorf",
-  "coronaContacts": false,
-  "dateOfBirth": "1960-09-11",
-  "email": "t.schulz@t-online.de",
-  "firstName": "Tim",
-  "fluImmunization": true,
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1989-10-13",
+  "email": "f.lange@web.de",
+  "firstName": "Fin",
+  "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 37,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "M975535611",
-  "lastName": "Schulz",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "Z582032731",
+  "lastName": "Lange",
   "nationality": "deutsch",
-  "phoneNumber": "1021077102217",
+  "phoneNumber": "22292706510",
   "preIllnesses": [
-    ""
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Hubei"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Aarhusweg",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Tulpenweg 30",
   "symptoms": [
-    "Husten",
+    "Atemschwierigkeiten",
     "Halschmerzen",
-    "Kopfschmerzen",
-    "Fieber"
+    "Erk\u00e4ltung"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "30305"
+  "weakenedImmuneSystem": false,
+  "zip": "66794"
 }

--- a/server/src/main/resources/sample_data/persons/person52.json
+++ b/server/src/main/resources/sample_data/persons/person52.json
@@ -1,31 +1,28 @@
 {
-  "city": "D\u00fcsseldorf",
-  "coronaContacts": false,
-  "dateOfBirth": "1950-07-24",
-  "email": "p.mueller@gmail.de",
-  "firstName": "Petra",
-  "fluImmunization": false,
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1941-09-14",
+  "email": "d.schroeder@gmx.de",
+  "firstName": "Daniela",
+  "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 54,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "D185973340",
-  "lastName": "M\u00fcller",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "I582452834",
+  "lastName": "Schr\u00f6der",
   "nationality": "deutsch",
-  "phoneNumber": "7652775841",
+  "phoneNumber": "23924010758",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "New York"
+    "GrandEst"
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordufer",
+  "street": "Schernerweg 91",
   "symptoms": [
-    "Atemschwierigkeiten",
-    "Erk\u00e4ltung",
-    "Gelenkschmerzen",
-    "Halschmerzen"
+    "Halschmerzen",
+    "Husten"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "16928"
+  "weakenedImmuneSystem": true,
+  "zip": "66814"
 }

--- a/server/src/main/resources/sample_data/persons/person53.json
+++ b/server/src/main/resources/sample_data/persons/person53.json
@@ -1,33 +1,33 @@
 {
-  "city": "M\u00fcnchen",
+  "city": "Neunkirchen",
   "coronaContacts": false,
-  "dateOfBirth": "1927-07-09",
-  "email": "j.winkler@gmail.de",
+  "dateOfBirth": "1955-09-12",
+  "email": "j.sommer@t-online.de",
   "firstName": "Jana",
-  "fluImmunization": false,
+  "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 18,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "Y792738367",
-  "lastName": "Winkler",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "E914799481",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "10011010658102",
+  "phoneNumber": "36153051105",
   "preIllnesses": [
     "Krebserkrankung"
   ],
   "riskAreas": [
-    ""
+    "Moscow"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Aarhusweg",
+  "street": "Nordstra\u00dfe 18",
   "symptoms": [
     "Husten",
-    "Atemschwierigkeiten",
-    "Fieber",
-    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Halschmerzen",
     "Schnupfen",
-    "Kopfschmerzen"
+    "Fieber",
+    "Kopfschmerzen",
+    "Erk\u00e4ltung"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "910702"
+  "weakenedImmuneSystem": false,
+  "zip": "66204"
 }

--- a/server/src/main/resources/sample_data/persons/person54.json
+++ b/server/src/main/resources/sample_data/persons/person54.json
@@ -1,32 +1,28 @@
 {
-  "city": "Bochum",
+  "city": "Saarbr\u00fccken",
   "coronaContacts": true,
-  "dateOfBirth": "1974-02-01",
-  "email": "s.wagner@gmail.de",
-  "firstName": "Susanne",
+  "dateOfBirth": "1952-11-26",
+  "email": "l.mueller@posteo.de",
+  "firstName": "Lisa",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 36,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "W577934499",
-  "lastName": "Wagner",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "L358303887",
+  "lastName": "M\u00fcller",
   "nationality": "deutsch",
-  "phoneNumber": "2786814473",
+  "phoneNumber": "97117980108",
   "preIllnesses": [
-    "Krebserkrankung"
+    ""
   ],
   "riskAreas": [
     "Hubei"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Hohenzollerstra\u00dfe 30",
   "symptoms": [
-    "Kopfschmerzen",
-    "Gelenkschmerzen",
-    "Husten",
-    "Atemschwierigkeiten",
-    "Schnupfen"
+    "Fieber",
+    "Atemschwierigkeiten"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "73121"
+  "weakenedImmuneSystem": false,
+  "zip": "66246"
 }

--- a/server/src/main/resources/sample_data/persons/person55.json
+++ b/server/src/main/resources/sample_data/persons/person55.json
@@ -1,28 +1,33 @@
 {
-  "city": "Frankfurt",
-  "coronaContacts": true,
-  "dateOfBirth": "1990-04-26",
-  "email": "t.bauer@posteo.de",
-  "firstName": "Tim",
-  "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 78,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "Y539625898",
-  "lastName": "Bauer",
+  "city": "Heusweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1956-06-09",
+  "email": "i.schmidt@t-online.de",
+  "firstName": "Isabella",
+  "fluImmunization": false,
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "Y835172306",
+  "lastName": "Schmidt",
   "nationality": "deutsch",
-  "phoneNumber": "2370589578",
+  "phoneNumber": "051531010195",
   "preIllnesses": [
-    ""
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Hubei"
+    ""
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Haidth\u00f6heAarweg",
+  "street": "Aastwiete 5",
   "symptoms": [
-    "Schnupfen"
+    "Schnupfen",
+    "Halschmerzen",
+    "Fieber",
+    "Husten",
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Kopfschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "11467"
+  "zip": "66585"
 }

--- a/server/src/main/resources/sample_data/persons/person56.json
+++ b/server/src/main/resources/sample_data/persons/person56.json
@@ -1,35 +1,31 @@
 {
-  "city": "Frankfurt",
+  "city": "Bous",
   "coronaContacts": false,
-  "dateOfBirth": "1961-03-29",
-  "email": "d.lange@web.de",
-  "firstName": "Daniela",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 38,
+  "dateOfBirth": "1955-09-16",
+  "email": "t.schroeder@web.de",
+  "firstName": "Tim",
+  "fluImmunization": true,
+  "gender": "male",
   "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "C369085407",
-  "lastName": "Lange",
+  "insuranceMembershipNumber": "F632794158",
+  "lastName": "Schr\u00f6der",
   "nationality": "deutsch",
-  "phoneNumber": "81092268018",
+  "phoneNumber": "401034501054",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "New York"
+    "Madrid"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Haidth\u00f6heAarweg",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Schernerweg 47",
   "symptoms": [
     "Atemschwierigkeiten",
-    "Fieber",
-    "Kopfschmerzen",
-    "Schnupfen",
+    "Halschmerzen",
     "Husten",
-    "Gelenkschmerzen",
     "Erk\u00e4ltung",
-    "Halschmerzen"
+    "Kopfschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "22535"
+  "zip": "66667"
 }

--- a/server/src/main/resources/sample_data/persons/person57.json
+++ b/server/src/main/resources/sample_data/persons/person57.json
@@ -1,33 +1,28 @@
 {
-  "city": "Bochum",
+  "city": "Sulzbach",
   "coronaContacts": true,
-  "dateOfBirth": "1932-05-21",
-  "email": "p.mueller@t-online.de",
-  "firstName": "Peter",
+  "dateOfBirth": "1964-11-10",
+  "email": "m.schulze@t-online.de",
+  "firstName": "Marie",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 38,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "W164331134",
-  "lastName": "M\u00fcller",
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "U536164913",
+  "lastName": "Schulze",
   "nationality": "deutsch",
-  "phoneNumber": "396910071084",
+  "phoneNumber": "4796275705",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "New York"
+    "Madrid"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Nordtstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Eisenbahnstra\u00dfe 55",
   "symptoms": [
-    "Gelenkschmerzen",
-    "Erk\u00e4ltung",
-    "Fieber",
-    "Schnupfen",
-    "Kopfschmerzen",
-    "Halschmerzen"
+    "Husten",
+    "Fieber"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "731064"
+  "weakenedImmuneSystem": true,
+  "zip": "664100"
 }

--- a/server/src/main/resources/sample_data/persons/person58.json
+++ b/server/src/main/resources/sample_data/persons/person58.json
@@ -1,34 +1,25 @@
 {
-  "city": "Kiel",
+  "city": "V\u00f6lklingen",
   "coronaContacts": true,
-  "dateOfBirth": "1940-09-04",
-  "email": "a.winter@gmail.de",
-  "firstName": "Anna",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 49,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "Y271092615",
-  "lastName": "Winter",
+  "dateOfBirth": "1959-06-13",
+  "email": "h.schulz@posteo.de",
+  "firstName": "Hans",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "I368018471",
+  "lastName": "Schulz",
   "nationality": "deutsch",
-  "phoneNumber": "5371473210",
+  "phoneNumber": "90921075571",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
     "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Aastwiete",
-  "symptoms": [
-    "Gelenkschmerzen",
-    "Schnupfen",
-    "Erk\u00e4ltung",
-    "Husten",
-    "Atemschwierigkeiten",
-    "Fieber",
-    "Halschmerzen"
-  ],
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hohenzollerstra\u00dfe 17",
+  "symptoms": [],
   "weakenedImmuneSystem": false,
-  "zip": "96325"
+  "zip": "66856"
 }

--- a/server/src/main/resources/sample_data/persons/person59.json
+++ b/server/src/main/resources/sample_data/persons/person59.json
@@ -1,34 +1,28 @@
 {
-  "city": "Kiel",
+  "city": "Homburg",
   "coronaContacts": false,
-  "dateOfBirth": "1929-11-22",
-  "email": "p.weber@gmx.de",
-  "firstName": "Peter",
-  "fluImmunization": false,
+  "dateOfBirth": "1978-10-10",
+  "email": "k.bauer@gmx.de",
+  "firstName": "Karl",
+  "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 5,
   "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "J178954113",
-  "lastName": "Weber",
+  "insuranceMembershipNumber": "J422076028",
+  "lastName": "Bauer",
   "nationality": "deutsch",
-  "phoneNumber": "7480162456",
+  "phoneNumber": "73121727110",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Hubei"
+    ""
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Abbachstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Nordufer 40",
   "symptoms": [
-    "Atemschwierigkeiten",
-    "Halschmerzen",
-    "Gelenkschmerzen",
     "Kopfschmerzen",
-    "Husten",
-    "Erk\u00e4ltung",
-    "Schnupfen"
+    "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "60983"
+  "zip": "661051"
 }

--- a/server/src/main/resources/sample_data/persons/person6.json
+++ b/server/src/main/resources/sample_data/persons/person6.json
@@ -1,30 +1,33 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": false,
-  "dateOfBirth": "1943-04-18",
-  "email": "k.schulze@gmail.de",
-  "firstName": "Kai",
-  "fluImmunization": false,
+  "city": "Saarlouis",
+  "coronaContacts": true,
+  "dateOfBirth": "1962-01-19",
+  "email": "f.klein@t-online.de",
+  "firstName": "Franz",
+  "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 55,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "M881913386",
-  "lastName": "Schulze",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "P330035022",
+  "lastName": "Klein",
   "nationality": "deutsch",
-  "phoneNumber": "2997376311",
+  "phoneNumber": "83930110031",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "GrandEst"
+    "Tirol"
   ],
   "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordtstra\u00dfe",
+  "street": "Im KramersfeldAar\u00f6stra\u00dfe 42",
   "symptoms": [
     "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
     "Fieber",
-    "Atemschwierigkeiten"
+    "Husten",
+    "Schnupfen"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "56670"
+  "zip": "66183"
 }

--- a/server/src/main/resources/sample_data/persons/person60.json
+++ b/server/src/main/resources/sample_data/persons/person60.json
@@ -1,35 +1,34 @@
 {
-  "city": "D\u00fcsseldorf",
+  "city": "Dudweiler",
   "coronaContacts": true,
-  "dateOfBirth": "1940-07-17",
-  "email": "a.schulze@web.de",
-  "firstName": "Anna",
-  "fluImmunization": true,
-  "gender": "female",
-  "houseNumber": 17,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "K644725317",
-  "lastName": "Schulze",
+  "dateOfBirth": "1959-09-19",
+  "email": "f.schmidt@t-online.de",
+  "firstName": "Franz",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "U179634081",
+  "lastName": "Schmidt",
   "nationality": "deutsch",
-  "phoneNumber": "0002578729",
+  "phoneNumber": "5782911467",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
     ""
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "B\u00fcckerheide",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Hafenstra\u00dfe 52",
   "symptoms": [
-    "Gelenkschmerzen",
     "Kopfschmerzen",
-    "Atemschwierigkeiten",
-    "Schnupfen",
-    "Erk\u00e4ltung",
-    "Husten",
     "Fieber",
-    "Halschmerzen"
+    "Atemschwierigkeiten",
+    "Gelenkschmerzen",
+    "Halschmerzen",
+    "Husten",
+    "Erk\u00e4ltung",
+    "Schnupfen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "59526"
+  "zip": "66691"
 }

--- a/server/src/main/resources/sample_data/persons/person61.json
+++ b/server/src/main/resources/sample_data/persons/person61.json
@@ -1,33 +1,31 @@
 {
-  "city": "K\u00f6ln",
+  "city": "Dudweiler",
   "coronaContacts": true,
-  "dateOfBirth": "1972-11-26",
-  "email": "j.schroeder@gmx.de",
-  "firstName": "Jana",
+  "dateOfBirth": "1977-06-17",
+  "email": "a.wagner@gmail.de",
+  "firstName": "Anna",
   "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 18,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "O436824737",
-  "lastName": "Schr\u00f6der",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "S265564833",
+  "lastName": "Wagner",
   "nationality": "deutsch",
-  "phoneNumber": "99309728109",
+  "phoneNumber": "414310842104",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    ""
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Niekampsweg",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Eisenbahnstra\u00dfe 68",
   "symptoms": [
-    "Erk\u00e4ltung",
-    "Gelenkschmerzen",
-    "Atemschwierigkeiten",
-    "Kopfschmerzen",
+    "Husten",
     "Halschmerzen",
-    "Schnupfen"
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "103091"
+  "zip": "661810"
 }

--- a/server/src/main/resources/sample_data/persons/person62.json
+++ b/server/src/main/resources/sample_data/persons/person62.json
@@ -1,34 +1,28 @@
 {
-  "city": "K\u00f6ln",
+  "city": "Bous",
   "coronaContacts": true,
-  "dateOfBirth": "1938-07-11",
-  "email": "k.wagner@gmx.de",
-  "firstName": "Kai",
-  "fluImmunization": true,
+  "dateOfBirth": "2002-08-29",
+  "email": "c.sommer@web.de",
+  "firstName": "Christopher",
+  "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 61,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "Y410315830",
-  "lastName": "Wagner",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "O319068042",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "2785851010104",
+  "phoneNumber": "1084104731064",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "New York"
+    "Hubei"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Waldstra\u00dfe 9",
   "symptoms": [
     "Kopfschmerzen",
-    "Erk\u00e4ltung",
-    "Schnupfen",
-    "Atemschwierigkeiten",
-    "Gelenkschmerzen",
-    "Fieber",
-    "Husten"
+    "Halschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "33484"
+  "zip": "66027"
 }

--- a/server/src/main/resources/sample_data/persons/person63.json
+++ b/server/src/main/resources/sample_data/persons/person63.json
@@ -1,30 +1,33 @@
 {
-  "city": "K\u00f6ln",
-  "coronaContacts": false,
-  "dateOfBirth": "1968-01-10",
-  "email": "m.winter@posteo.de",
-  "firstName": "Marie",
-  "fluImmunization": true,
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1934-02-11",
+  "email": "a.winkler@web.de",
+  "firstName": "Anna",
+  "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 89,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "B819228743",
-  "lastName": "Winter",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "X435775088",
+  "lastName": "Winkler",
   "nationality": "deutsch",
-  "phoneNumber": "15710473384",
+  "phoneNumber": "3714732104",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Hubei"
+    "Tirol"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "B\u00fcckerheide",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Z\u00e4hringerstra\u00dfe 78",
   "symptoms": [
+    "Gelenkschmerzen",
     "Erk\u00e4ltung",
+    "Schnupfen",
+    "Halschmerzen",
     "Husten",
-    "Halschmerzen"
+    "Atemschwierigkeiten",
+    "Fieber"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "42199"
+  "zip": "66632"
 }

--- a/server/src/main/resources/sample_data/persons/person64.json
+++ b/server/src/main/resources/sample_data/persons/person64.json
@@ -1,31 +1,31 @@
 {
-  "city": "Hamburg",
+  "city": "Saarbr\u00fccken",
   "coronaContacts": true,
-  "dateOfBirth": "1985-07-21",
-  "email": "h.peters@web.de",
-  "firstName": "Hans",
-  "fluImmunization": false,
+  "dateOfBirth": "1999-05-16",
+  "email": "b.winkler@t-online.de",
+  "firstName": "Ben",
+  "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 73,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "M946066287",
-  "lastName": "Peters",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "B712335251",
+  "lastName": "Winkler",
   "nationality": "deutsch",
-  "phoneNumber": "771034541001",
+  "phoneNumber": "910107480162",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
-  ],
-  "riskAreas": [
     ""
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordtstra\u00dfe",
-  "symptoms": [
-    "Husten",
-    "Gelenkschmerzen",
-    "Schnupfen",
-    "Atemschwierigkeiten"
+  "riskAreas": [
+    "Madrid"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "38026"
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Sonnenweg 93",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Husten",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Kopfschmerzen"
+  ],
+  "weakenedImmuneSystem": false,
+  "zip": "66565"
 }

--- a/server/src/main/resources/sample_data/persons/person65.json
+++ b/server/src/main/resources/sample_data/persons/person65.json
@@ -1,33 +1,31 @@
 {
-  "city": "K\u00f6ln",
-  "coronaContacts": false,
-  "dateOfBirth": "1938-08-29",
-  "email": "d.lange@web.de",
-  "firstName": "Daniela",
-  "fluImmunization": true,
-  "gender": "female",
-  "houseNumber": 91,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "T785826598",
-  "lastName": "Lange",
+  "city": "Dudweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1962-09-12",
+  "email": "d.winter@gmail.de",
+  "firstName": "Daniel",
+  "fluImmunization": false,
+  "gender": "male",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "Q250088694",
+  "lastName": "Winter",
   "nationality": "deutsch",
-  "phoneNumber": "28743152710",
+  "phoneNumber": "2398680002",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Hubei"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Aastwiete",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Rosenstra\u00dfe 42",
   "symptoms": [
-    "Kopfschmerzen",
-    "Husten",
+    "Schnupfen",
     "Erk\u00e4ltung",
-    "Halschmerzen",
-    "Fieber",
-    "Atemschwierigkeiten"
+    "Atemschwierigkeiten",
+    "Gelenkschmerzen",
+    "Kopfschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "20549"
+  "zip": "66787"
 }

--- a/server/src/main/resources/sample_data/persons/person66.json
+++ b/server/src/main/resources/sample_data/persons/person66.json
@@ -1,31 +1,28 @@
 {
-  "city": "Frankfurt",
+  "city": "Dudweiler",
   "coronaContacts": true,
-  "dateOfBirth": "1948-05-31",
-  "email": "k.richter@posteo.de",
-  "firstName": "Karl",
+  "dateOfBirth": "1963-11-04",
+  "email": "d.peters@gmail.de",
+  "firstName": "Daniela",
   "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 15,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "Y433910025",
-  "lastName": "Richter",
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "U874364174",
+  "lastName": "Peters",
   "nationality": "deutsch",
-  "phoneNumber": "54990410530",
+  "phoneNumber": "694100974109",
   "preIllnesses": [
     "Krebserkrankung"
   ],
   "riskAreas": [
-    "GrandEst"
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordtstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Hohenzollerstra\u00dfe 29",
   "symptoms": [
-    "Kopfschmerzen",
-    "Atemschwierigkeiten",
-    "Fieber",
-    "Gelenkschmerzen"
+    "Erk\u00e4ltung",
+    "Husten"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "742610"
+  "zip": "66097"
 }

--- a/server/src/main/resources/sample_data/persons/person67.json
+++ b/server/src/main/resources/sample_data/persons/person67.json
@@ -1,34 +1,31 @@
 {
-  "city": "Frankfurt",
-  "coronaContacts": true,
-  "dateOfBirth": "1945-09-26",
-  "email": "m.richter@web.de",
-  "firstName": "Marie",
-  "fluImmunization": true,
-  "gender": "female",
-  "houseNumber": 72,
+  "city": "V\u00f6lklingen",
+  "coronaContacts": false,
+  "dateOfBirth": "1986-07-23",
+  "email": "j.lange@gmx.de",
+  "firstName": "Jens",
+  "fluImmunization": false,
+  "gender": "male",
   "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "F452313624",
-  "lastName": "Richter",
+  "insuranceMembershipNumber": "O672440825",
+  "lastName": "Lange",
   "nationality": "deutsch",
-  "phoneNumber": "103310918785",
+  "phoneNumber": "3689702838",
   "preIllnesses": [
     "Krebserkrankung"
   ],
   "riskAreas": [
-    ""
+    "Madrid"
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Im KramersfeldAar\u00f6stra\u00dfe",
+  "street": "S\u00fcdweg 84",
   "symptoms": [
-    "Fieber",
-    "Kopfschmerzen",
-    "Gelenkschmerzen",
     "Atemschwierigkeiten",
+    "Gelenkschmerzen",
     "Erk\u00e4ltung",
-    "Husten",
+    "Fieber",
     "Halschmerzen"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "10883"
+  "zip": "66786"
 }

--- a/server/src/main/resources/sample_data/persons/person68.json
+++ b/server/src/main/resources/sample_data/persons/person68.json
@@ -1,33 +1,30 @@
 {
-  "city": "Berlin",
-  "coronaContacts": true,
-  "dateOfBirth": "1934-08-22",
-  "email": "d.schroeder@t-online.de",
-  "firstName": "Daniela",
+  "city": "Saarlouis",
+  "coronaContacts": false,
+  "dateOfBirth": "1943-06-16",
+  "email": "o.schroeder@posteo.de",
+  "firstName": "Olivia",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 89,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "N293253475",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "C471904990",
   "lastName": "Schr\u00f6der",
   "nationality": "deutsch",
-  "phoneNumber": "4064039106",
+  "phoneNumber": "58441910866",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "New York"
+    "Madrid"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Abbachstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Nordtstra\u00dfe 44",
   "symptoms": [
-    "Kopfschmerzen",
-    "Erk\u00e4ltung",
-    "Halschmerzen",
     "Gelenkschmerzen",
-    "Atemschwierigkeiten",
-    "Husten"
+    "Fieber",
+    "Halschmerzen",
+    "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "18017"
+  "zip": "66240"
 }

--- a/server/src/main/resources/sample_data/persons/person69.json
+++ b/server/src/main/resources/sample_data/persons/person69.json
@@ -1,26 +1,29 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": false,
-  "dateOfBirth": "1955-09-05",
-  "email": "l.schulz@web.de",
-  "firstName": "Lisa",
+  "city": "Dudweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1999-11-29",
+  "email": "d.klein@posteo.de",
+  "firstName": "Daniel",
   "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 31,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "Z808881871",
-  "lastName": "Schulz",
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "U610778600",
+  "lastName": "Klein",
   "nationality": "deutsch",
-  "phoneNumber": "30047108686",
+  "phoneNumber": "83103016571",
   "preIllnesses": [
     ""
   ],
   "riskAreas": [
-    "GrandEst"
+    ""
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Schernerweg",
-  "symptoms": [],
-  "weakenedImmuneSystem": false,
-  "zip": "75243"
+  "street": "Bismarckstra\u00dfe 98",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Halschmerzen"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66208"
 }

--- a/server/src/main/resources/sample_data/persons/person7.json
+++ b/server/src/main/resources/sample_data/persons/person7.json
@@ -1,35 +1,25 @@
 {
-  "city": "D\u00fcsseldorf",
-  "coronaContacts": false,
-  "dateOfBirth": "1949-09-04",
-  "email": "d.schulze@t-online.de",
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1998-07-24",
+  "email": "d.mueller@t-online.de",
   "firstName": "Daniela",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 51,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "J554200826",
-  "lastName": "Schulze",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "D154318806",
+  "lastName": "M\u00fcller",
   "nationality": "deutsch",
-  "phoneNumber": "01080132677",
+  "phoneNumber": "5133387262",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
     ""
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Schernerweg",
-  "symptoms": [
-    "Gelenkschmerzen",
-    "Fieber",
-    "Halschmerzen",
-    "Schnupfen",
-    "Kopfschmerzen",
-    "Husten",
-    "Atemschwierigkeiten",
-    "Erk\u00e4ltung"
-  ],
+  "street": "Sonnenweg 59",
+  "symptoms": [],
   "weakenedImmuneSystem": true,
-  "zip": "02606"
+  "zip": "66317"
 }

--- a/server/src/main/resources/sample_data/persons/person70.json
+++ b/server/src/main/resources/sample_data/persons/person70.json
@@ -1,33 +1,33 @@
 {
-  "city": "K\u00f6ln",
+  "city": "Homburg",
   "coronaContacts": true,
-  "dateOfBirth": "1974-12-02",
-  "email": "j.schroeder@t-online.de",
-  "firstName": "Jens",
+  "dateOfBirth": "1952-03-30",
+  "email": "k.mueller@posteo.de",
+  "firstName": "Kai",
   "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 73,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "E808897689",
-  "lastName": "Schr\u00f6der",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "P244096091",
+  "lastName": "M\u00fcller",
   "nationality": "deutsch",
-  "phoneNumber": "6738302843",
+  "phoneNumber": "0672400499",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Tirol"
+    "Hubei"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordufer",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Schernerweg 42",
   "symptoms": [
     "Atemschwierigkeiten",
-    "Schnupfen",
-    "Husten",
-    "Gelenkschmerzen",
     "Fieber",
-    "Halschmerzen"
+    "Husten",
+    "Schnupfen",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "599105"
+  "zip": "664710"
 }

--- a/server/src/main/resources/sample_data/persons/person71.json
+++ b/server/src/main/resources/sample_data/persons/person71.json
@@ -1,31 +1,33 @@
 {
-  "city": "Freiburg",
+  "city": "V\u00f6lklingen",
   "coronaContacts": true,
-  "dateOfBirth": "1938-06-23",
-  "email": "t.lange@gmx.de",
-  "firstName": "Tim",
+  "dateOfBirth": "1933-11-25",
+  "email": "m.lange@gmail.de",
+  "firstName": "Matthias",
   "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 90,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "Q243980993",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "A380016058",
   "lastName": "Lange",
   "nationality": "deutsch",
-  "phoneNumber": "6624628733",
+  "phoneNumber": "32910668516",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    ""
   ],
   "riskAreas": [
-    "Tirol"
+    "GrandEst"
   ],
   "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Aastwiete",
+  "street": "Bismarckstra\u00dfe 12",
   "symptoms": [
-    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
     "Schnupfen",
-    "Kopfschmerzen",
-    "Husten"
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Husten",
+    "Fieber",
+    "Kopfschmerzen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "27086"
+  "weakenedImmuneSystem": false,
+  "zip": "66227"
 }

--- a/server/src/main/resources/sample_data/persons/person72.json
+++ b/server/src/main/resources/sample_data/persons/person72.json
@@ -1,30 +1,29 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": false,
-  "dateOfBirth": "1999-05-13",
-  "email": "k.winkler@posteo.de",
-  "firstName": "Kai",
+  "city": "Riegelsberg",
+  "coronaContacts": true,
+  "dateOfBirth": "1941-12-25",
+  "email": "p.wagner@gmx.de",
+  "firstName": "Petra",
   "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 26,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "Y614237373",
-  "lastName": "Winkler",
+  "gender": "female",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "P913198930",
+  "lastName": "Wagner",
   "nationality": "deutsch",
-  "phoneNumber": "109901391083",
+  "phoneNumber": "41104593327",
   "preIllnesses": [
     "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Hubei"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Abbendiekshof",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Aastwiete 58",
   "symptoms": [
-    "Halschmerzen",
-    "Fieber",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
     "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "54033"
+  "zip": "66956"
 }

--- a/server/src/main/resources/sample_data/persons/person73.json
+++ b/server/src/main/resources/sample_data/persons/person73.json
@@ -1,33 +1,33 @@
 {
-  "city": "Freiburg",
+  "city": "Neunkirchen",
   "coronaContacts": true,
-  "dateOfBirth": "1940-08-15",
-  "email": "p.weber@gmail.de",
-  "firstName": "Petra",
-  "fluImmunization": false,
+  "dateOfBirth": "1935-09-07",
+  "email": "l.schulze@t-online.de",
+  "firstName": "Lisa",
+  "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 18,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "E310659326",
-  "lastName": "Weber",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "O241674152",
+  "lastName": "Schulze",
   "nationality": "deutsch",
-  "phoneNumber": "1753556093",
+  "phoneNumber": "98225871103",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "New York"
+    ""
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordufer",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Rosenstra\u00dfe 74",
   "symptoms": [
-    "Erk\u00e4ltung",
-    "Gelenkschmerzen",
+    "Husten",
     "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
     "Schnupfen",
-    "Kopfschmerzen",
-    "Fieber"
+    "Gelenkschmerzen",
+    "Fieber",
+    "Halschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "04899"
+  "zip": "66718"
 }

--- a/server/src/main/resources/sample_data/persons/person74.json
+++ b/server/src/main/resources/sample_data/persons/person74.json
@@ -1,34 +1,31 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": false,
-  "dateOfBirth": "1984-03-24",
-  "email": "a.winkler@gmail.de",
-  "firstName": "Anna",
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1997-09-02",
+  "email": "p.sommer@gmail.de",
+  "firstName": "Peter",
   "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 97,
+  "gender": "male",
   "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "E109815572",
-  "lastName": "Winkler",
+  "insuranceMembershipNumber": "V679069250",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "872810080110",
+  "phoneNumber": "170462210106",
   "preIllnesses": [
-    "Herz-Kreislauf"
-  ],
-  "riskAreas": [
     ""
   ],
+  "riskAreas": [
+    "GrandEst"
+  ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Aarhusweg",
+  "street": "Hauptstra\u00dfe 48",
   "symptoms": [
-    "Kopfschmerzen",
-    "Husten",
-    "Atemschwierigkeiten",
+    "Fieber",
     "Gelenkschmerzen",
+    "Atemschwierigkeiten",
     "Erk\u00e4ltung",
-    "Schnupfen",
-    "Fieber"
+    "Halschmerzen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "062103"
+  "zip": "66766"
 }

--- a/server/src/main/resources/sample_data/persons/person75.json
+++ b/server/src/main/resources/sample_data/persons/person75.json
@@ -1,30 +1,25 @@
 {
-  "city": "Kiel",
-  "coronaContacts": true,
-  "dateOfBirth": "1937-05-01",
-  "email": "p.bauer@gmail.de",
-  "firstName": "Peter",
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "1951-09-13",
+  "email": "k.schmitt@web.de",
+  "firstName": "Karl",
   "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 67,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "O706666479",
-  "lastName": "Bauer",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "T136052248",
+  "lastName": "Schmitt",
   "nationality": "deutsch",
-  "phoneNumber": "81062118233",
+  "phoneNumber": "33752431010",
   "preIllnesses": [
-    ""
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
     "New York"
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordstra\u00dfe",
-  "symptoms": [
-    "Atemschwierigkeiten",
-    "Kopfschmerzen",
-    "Husten"
-  ],
-  "weakenedImmuneSystem": true,
-  "zip": "45461"
+  "street": "Kaiserstra\u00dfe 78",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "66033"
 }

--- a/server/src/main/resources/sample_data/persons/person76.json
+++ b/server/src/main/resources/sample_data/persons/person76.json
@@ -1,26 +1,28 @@
 {
-  "city": "Berlin",
+  "city": "Saarlouis",
   "coronaContacts": false,
-  "dateOfBirth": "1935-08-02",
-  "email": "j.richter@gmx.de",
-  "firstName": "Jan",
+  "dateOfBirth": "1988-09-10",
+  "email": "a.richter@t-online.de",
+  "firstName": "Annika",
   "fluImmunization": true,
-  "gender": "male",
-  "houseNumber": 5,
+  "gender": "female",
   "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "V401048226",
+  "insuranceMembershipNumber": "R735297732",
   "lastName": "Richter",
   "nationality": "deutsch",
-  "phoneNumber": "100217610591",
+  "phoneNumber": "39599105342",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Hubei"
+    ""
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "B\u00fcckerheide",
-  "symptoms": [],
-  "weakenedImmuneSystem": false,
-  "zip": "33974"
+  "street": "Bismarckstra\u00dfe 66",
+  "symptoms": [
+    "Halschmerzen",
+    "Atemschwierigkeiten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "66364"
 }

--- a/server/src/main/resources/sample_data/persons/person77.json
+++ b/server/src/main/resources/sample_data/persons/person77.json
@@ -1,34 +1,31 @@
 {
-  "city": "Freiburg",
+  "city": "Homburg",
   "coronaContacts": false,
-  "dateOfBirth": "1985-10-08",
-  "email": "j.mueller@gmail.de",
-  "firstName": "Jan",
+  "dateOfBirth": "1952-07-05",
+  "email": "o.berger@gmail.de",
+  "firstName": "Olivia",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 12,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "A780884334",
-  "lastName": "M\u00fcller",
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "M360767346",
+  "lastName": "Berger",
   "nationality": "deutsch",
-  "phoneNumber": "96108562185",
+  "phoneNumber": "4628733427",
   "preIllnesses": [
-    "Krebserkrankung"
+    ""
   ],
   "riskAreas": [
-    "Madrid"
+    "Hubei"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Aarhusweg",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Im KramersfeldAar\u00f6stra\u00dfe 71",
   "symptoms": [
+    "Fieber",
     "Erk\u00e4ltung",
     "Schnupfen",
-    "Atemschwierigkeiten",
-    "Gelenkschmerzen",
-    "Kopfschmerzen",
     "Husten",
-    "Fieber"
+    "Gelenkschmerzen"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "63159"
+  "zip": "66668"
 }

--- a/server/src/main/resources/sample_data/persons/person78.json
+++ b/server/src/main/resources/sample_data/persons/person78.json
@@ -1,28 +1,34 @@
 {
-  "city": "Freiburg",
+  "city": "Homburg",
   "coronaContacts": false,
-  "dateOfBirth": "1957-12-26",
-  "email": "d.weber@posteo.de",
-  "firstName": "Daniel",
-  "fluImmunization": true,
+  "dateOfBirth": "1979-06-10",
+  "email": "f.richter@gmx.de",
+  "firstName": "Franz",
+  "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 97,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "R695647539",
-  "lastName": "Weber",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "L431165907",
+  "lastName": "Richter",
   "nationality": "deutsch",
-  "phoneNumber": "10265511047",
+  "phoneNumber": "0331739363",
   "preIllnesses": [
-    ""
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Hubei"
+    ""
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Abbachstra\u00dfe",
+  "street": "Poststra\u00dfe 41",
   "symptoms": [
-    "Husten"
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Husten",
+    "Halschmerzen",
+    "Schnupfen",
+    "Kopfschmerzen",
+    "Fieber",
+    "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "41212"
+  "zip": "66467"
 }

--- a/server/src/main/resources/sample_data/persons/person79.json
+++ b/server/src/main/resources/sample_data/persons/person79.json
@@ -1,32 +1,33 @@
 {
-  "city": "Freiburg",
+  "city": "P\u00fcttlingen",
   "coronaContacts": false,
-  "dateOfBirth": "1953-07-25",
-  "email": "s.peters@gmail.de",
-  "firstName": "Susanne",
-  "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 38,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "N421856529",
-  "lastName": "Peters",
+  "dateOfBirth": "1931-10-24",
+  "email": "p.bauer@web.de",
+  "firstName": "Peter",
+  "fluImmunization": true,
+  "gender": "male",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "X789014168",
+  "lastName": "Bauer",
   "nationality": "deutsch",
-  "phoneNumber": "18398210622",
+  "phoneNumber": "6423536937",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
-  ],
-  "riskAreas": [
     ""
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Aastwiete",
-  "symptoms": [
-    "Atemschwierigkeiten",
-    "Fieber",
-    "Kopfschmerzen",
-    "Erk\u00e4ltung",
-    "Halschmerzen"
+  "riskAreas": [
+    "Madrid"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "47212"
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Poststra\u00dfe 83",
+  "symptoms": [
+    "Schnupfen",
+    "Kopfschmerzen",
+    "Gelenkschmerzen",
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Halschmerzen",
+    "Erk\u00e4ltung"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "661054"
 }

--- a/server/src/main/resources/sample_data/persons/person8.json
+++ b/server/src/main/resources/sample_data/persons/person8.json
@@ -1,30 +1,25 @@
 {
-  "city": "Kiel",
+  "city": "Saarlouis",
   "coronaContacts": true,
-  "dateOfBirth": "1982-02-20",
-  "email": "p.bauer@t-online.de",
-  "firstName": "Peter",
+  "dateOfBirth": "1978-07-29",
+  "email": "j.schmidt@gmx.de",
+  "firstName": "Jan",
   "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 10,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "G819112790",
-  "lastName": "Bauer",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "B721890096",
+  "lastName": "Schmidt",
   "nationality": "deutsch",
-  "phoneNumber": "11036193990",
+  "phoneNumber": "0260647468",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    ""
   ],
   "riskAreas": [
-    "New York"
+    "Hubei"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Nordstra\u00dfe",
-  "symptoms": [
-    "Atemschwierigkeiten",
-    "Erk\u00e4ltung",
-    "Fieber"
-  ],
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Bismarckstra\u00dfe 91",
+  "symptoms": [],
   "weakenedImmuneSystem": false,
-  "zip": "610998"
+  "zip": "66723"
 }

--- a/server/src/main/resources/sample_data/persons/person80.json
+++ b/server/src/main/resources/sample_data/persons/person80.json
@@ -1,32 +1,32 @@
 {
-  "city": "K\u00f6ln",
+  "city": "Heusweiler",
   "coronaContacts": true,
-  "dateOfBirth": "1957-06-15",
-  "email": "j.wagner@web.de",
-  "firstName": "Jan",
+  "dateOfBirth": "2005-07-05",
+  "email": "c.schulz@t-online.de",
+  "firstName": "Cornelius",
   "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 22,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "M400969989",
-  "lastName": "Wagner",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "A107099962",
+  "lastName": "Schulz",
   "nationality": "deutsch",
-  "phoneNumber": "56109245937",
+  "phoneNumber": "10312038750",
   "preIllnesses": [
     "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Madrid"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Abbachstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Eisenbahnstra\u00dfe 81",
   "symptoms": [
-    "Fieber",
-    "Atemschwierigkeiten",
+    "Husten",
     "Gelenkschmerzen",
-    "Halschmerzen",
-    "Kopfschmerzen"
+    "Atemschwierigkeiten",
+    "Schnupfen",
+    "Kopfschmerzen",
+    "Halschmerzen"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "654107"
+  "weakenedImmuneSystem": true,
+  "zip": "661097"
 }

--- a/server/src/main/resources/sample_data/persons/person81.json
+++ b/server/src/main/resources/sample_data/persons/person81.json
@@ -1,35 +1,32 @@
 {
-  "city": "Frankfurt",
-  "coronaContacts": true,
-  "dateOfBirth": "1997-07-22",
-  "email": "j.winter@gmail.de",
-  "firstName": "Jens",
+  "city": "Sulzbach",
+  "coronaContacts": false,
+  "dateOfBirth": "1986-04-07",
+  "email": "d.schulze@web.de",
+  "firstName": "Daniel",
   "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 57,
   "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "N683734594",
-  "lastName": "Winter",
+  "insuranceMembershipNumber": "U915599098",
+  "lastName": "Schulze",
   "nationality": "deutsch",
-  "phoneNumber": "721043410266",
+  "phoneNumber": "9845461567",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    ""
   ],
   "riskAreas": [
-    "Hubei"
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Im KramersfeldAar\u00f6stra\u00dfe",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Hohenzollerstra\u00dfe 31",
   "symptoms": [
-    "Fieber",
-    "Husten",
-    "Gelenkschmerzen",
-    "Schnupfen",
-    "Kopfschmerzen",
-    "Atemschwierigkeiten",
     "Halschmerzen",
-    "Erk\u00e4ltung"
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Gelenkschmerzen",
+    "Husten",
+    "Schnupfen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "97968"
+  "weakenedImmuneSystem": false,
+  "zip": "663410"
 }

--- a/server/src/main/resources/sample_data/persons/person82.json
+++ b/server/src/main/resources/sample_data/persons/person82.json
@@ -1,29 +1,32 @@
 {
-  "city": "M\u00fcnchen",
-  "coronaContacts": false,
-  "dateOfBirth": "1977-09-24",
-  "email": "p.mueller@gmail.de",
-  "firstName": "Peter",
+  "city": "V\u00f6lklingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1933-02-17",
+  "email": "i.sommer@gmail.de",
+  "firstName": "Isabella",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 88,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "N192185888",
-  "lastName": "M\u00fcller",
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "G730325223",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "88993756710",
+  "phoneNumber": "03397401104",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Tirol"
+    "Moscow"
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordstra\u00dfe",
+  "street": "Poststra\u00dfe 72",
   "symptoms": [
+    "Fieber",
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
     "Kopfschmerzen",
-    "Schnupfen"
+    "Halschmerzen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "82507"
+  "weakenedImmuneSystem": false,
+  "zip": "661002"
 }

--- a/server/src/main/resources/sample_data/persons/person83.json
+++ b/server/src/main/resources/sample_data/persons/person83.json
@@ -1,29 +1,32 @@
 {
-  "city": "Kiel",
+  "city": "P\u00fcttlingen",
   "coronaContacts": true,
-  "dateOfBirth": "1949-12-23",
-  "email": "m.klein@t-online.de",
-  "firstName": "Marie",
+  "dateOfBirth": "1941-12-12",
+  "email": "o.weber@t-online.de",
+  "firstName": "Olivia",
   "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 21,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "N596126873",
-  "lastName": "Klein",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "P344961731",
+  "lastName": "Weber",
   "nationality": "deutsch",
-  "phoneNumber": "75140105101",
+  "phoneNumber": "0163159996",
   "preIllnesses": [
-    ""
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Tirol"
+    "Madrid"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Nordtstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "B\u00fcckerheide 41",
   "symptoms": [
-    "Schnupfen",
-    "Kopfschmerzen"
+    "Halschmerzen",
+    "Fieber",
+    "Kopfschmerzen",
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Husten"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "38282"
+  "zip": "660104"
 }

--- a/server/src/main/resources/sample_data/persons/person84.json
+++ b/server/src/main/resources/sample_data/persons/person84.json
@@ -1,28 +1,34 @@
 {
-  "city": "Kiel",
-  "coronaContacts": false,
-  "dateOfBirth": "1956-01-23",
-  "email": "j.schroeder@gmx.de",
-  "firstName": "Jens",
-  "fluImmunization": false,
+  "city": "Sulzbach",
+  "coronaContacts": true,
+  "dateOfBirth": "1957-12-26",
+  "email": "d.bauer@posteo.de",
+  "firstName": "Daniel",
+  "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 58,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "M756387421",
-  "lastName": "Schr\u00f6der",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "N581942228",
+  "lastName": "Bauer",
   "nationality": "deutsch",
-  "phoneNumber": "3341918255",
+  "phoneNumber": "10265511047",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
     "Tirol"
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Schernerweg",
+  "street": "Hauptstra\u00dfe 97",
   "symptoms": [
-    "Kopfschmerzen"
+    "Halschmerzen",
+    "Husten",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Schnupfen",
+    "Erk\u00e4ltung",
+    "Atemschwierigkeiten",
+    "Fieber"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "141078"
+  "weakenedImmuneSystem": false,
+  "zip": "66412"
 }

--- a/server/src/main/resources/sample_data/persons/person85.json
+++ b/server/src/main/resources/sample_data/persons/person85.json
@@ -1,29 +1,29 @@
 {
-  "city": "Hamburg",
+  "city": "Saarlouis",
   "coronaContacts": false,
-  "dateOfBirth": "1965-02-08",
-  "email": "l.lange@posteo.de",
-  "firstName": "Lisa",
+  "dateOfBirth": "1974-10-17",
+  "email": "s.schulz@web.de",
+  "firstName": "Susanne",
   "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 49,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "F625749126",
-  "lastName": "Lange",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "Z182593686",
+  "lastName": "Schulz",
   "nationality": "deutsch",
-  "phoneNumber": "4125286692",
+  "phoneNumber": "21062244472",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "Madrid"
+    "Tirol"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Haidth\u00f6heAarweg 21",
   "symptoms": [
-    "Kopfschmerzen",
+    "Gelenkschmerzen",
+    "Atemschwierigkeiten",
     "Halschmerzen"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "627108"
+  "zip": "66646"
 }

--- a/server/src/main/resources/sample_data/persons/person86.json
+++ b/server/src/main/resources/sample_data/persons/person86.json
@@ -1,34 +1,33 @@
 {
-  "city": "Frankfurt",
+  "city": "Bous",
   "coronaContacts": true,
-  "dateOfBirth": "1956-09-17",
-  "email": "j.schulz@posteo.de",
-  "firstName": "Jens",
-  "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 3,
+  "dateOfBirth": "1926-07-26",
+  "email": "j.winter@gmail.de",
+  "firstName": "Jana",
+  "fluImmunization": true,
+  "gender": "female",
   "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "F938313402",
-  "lastName": "Schulz",
+  "insuranceMembershipNumber": "J889065340",
+  "lastName": "Winter",
   "nationality": "deutsch",
-  "phoneNumber": "107610767721",
+  "phoneNumber": "57561092459",
   "preIllnesses": [
     "Krebserkrankung"
   ],
   "riskAreas": [
-    "New York"
+    "Madrid"
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordstra\u00dfe",
+  "street": "Rosenstra\u00dfe 25",
   "symptoms": [
-    "Fieber",
-    "Atemschwierigkeiten",
-    "Husten",
-    "Schnupfen",
-    "Halschmerzen",
     "Erk\u00e4ltung",
-    "Kopfschmerzen"
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Halschmerzen",
+    "Kopfschmerzen",
+    "Fieber",
+    "Husten"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "34043"
+  "zip": "66752"
 }

--- a/server/src/main/resources/sample_data/persons/person87.json
+++ b/server/src/main/resources/sample_data/persons/person87.json
@@ -1,35 +1,34 @@
 {
-  "city": "Berlin",
+  "city": "Neunkirchen",
   "coronaContacts": false,
-  "dateOfBirth": "1967-01-15",
-  "email": "l.winkler@posteo.de",
-  "firstName": "Lisa",
+  "dateOfBirth": "1949-05-27",
+  "email": "m.schmitt@posteo.de",
+  "firstName": "Matthias",
   "fluImmunization": false,
-  "gender": "female",
-  "houseNumber": 54,
+  "gender": "male",
   "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "L671532152",
-  "lastName": "Winkler",
+  "insuranceMembershipNumber": "P725179752",
+  "lastName": "Schmitt",
   "nationality": "deutsch",
-  "phoneNumber": "4517133959",
+  "phoneNumber": "1610721043410",
   "preIllnesses": [
     ""
   ],
   "riskAreas": [
-    "Tirol"
+    "New York"
   ],
   "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordtstra\u00dfe",
+  "street": "Aastwiete 91",
   "symptoms": [
-    "Schnupfen",
-    "Gelenkschmerzen",
-    "Kopfschmerzen",
     "Halschmerzen",
     "Atemschwierigkeiten",
+    "Husten",
+    "Schnupfen",
+    "Kopfschmerzen",
     "Erk\u00e4ltung",
-    "Fieber",
-    "Husten"
+    "Gelenkschmerzen",
+    "Fieber"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "29233"
+  "zip": "66661"
 }

--- a/server/src/main/resources/sample_data/persons/person88.json
+++ b/server/src/main/resources/sample_data/persons/person88.json
@@ -1,34 +1,32 @@
 {
-  "city": "Frankfurt",
-  "coronaContacts": true,
-  "dateOfBirth": "1974-03-23",
-  "email": "a.winkler@posteo.de",
-  "firstName": "Anna",
-  "fluImmunization": true,
+  "city": "Dudweiler",
+  "coronaContacts": false,
+  "dateOfBirth": "1992-01-04",
+  "email": "o.lange@gmx.de",
+  "firstName": "Olivia",
+  "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 48,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "I845932321",
-  "lastName": "Winkler",
+  "insuranceCompany": "Techniker Krankenkasse",
+  "insuranceMembershipNumber": "A618371508",
+  "lastName": "Lange",
   "nationality": "deutsch",
-  "phoneNumber": "5310672910410",
+  "phoneNumber": "4388899375",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "New York"
+    "Tirol"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Niekampsweg",
+  "street": "Z\u00e4hringerstra\u00dfe 59",
   "symptoms": [
-    "Gelenkschmerzen",
-    "Schnupfen",
-    "Atemschwierigkeiten",
+    "Fieber",
     "Husten",
     "Kopfschmerzen",
-    "Halschmerzen",
-    "Fieber"
+    "Gelenkschmerzen",
+    "Schnupfen",
+    "Atemschwierigkeiten"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "711016"
+  "zip": "661098"
 }

--- a/server/src/main/resources/sample_data/persons/person89.json
+++ b/server/src/main/resources/sample_data/persons/person89.json
@@ -1,33 +1,29 @@
 {
-  "city": "Berlin",
+  "city": "Homburg",
   "coronaContacts": false,
-  "dateOfBirth": "1951-04-16",
-  "email": "k.richter@posteo.de",
-  "firstName": "Kai",
+  "dateOfBirth": "1949-12-23",
+  "email": "m.schmidt@t-online.de",
+  "firstName": "Marie",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 97,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "F573827182",
-  "lastName": "Richter",
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "K701133236",
+  "lastName": "Schmidt",
   "nationality": "deutsch",
-  "phoneNumber": "4545892975",
+  "phoneNumber": "75140105101",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
     "New York"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Nordtstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Bismarckstra\u00dfe 21",
   "symptoms": [
-    "Erk\u00e4ltung",
-    "Kopfschmerzen",
-    "Fieber",
-    "Schnupfen",
     "Halschmerzen",
-    "Gelenkschmerzen"
+    "Kopfschmerzen",
+    "Fieber"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "001107"
+  "weakenedImmuneSystem": true,
+  "zip": "66382"
 }

--- a/server/src/main/resources/sample_data/persons/person9.json
+++ b/server/src/main/resources/sample_data/persons/person9.json
@@ -1,28 +1,30 @@
 {
-  "city": "Frankfurt",
+  "city": "Bous",
   "coronaContacts": false,
-  "dateOfBirth": "1926-10-04",
-  "email": "l.peters@gmx.de",
-  "firstName": "Lisa",
+  "dateOfBirth": "1998-09-03",
+  "email": "p.berger@posteo.de",
+  "firstName": "Petra",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 20,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "V977358886",
-  "lastName": "Peters",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "S706907788",
+  "lastName": "Berger",
   "nationality": "deutsch",
-  "phoneNumber": "1838425135",
+  "phoneNumber": "21911036193",
   "preIllnesses": [
-    ""
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    ""
+    "Hubei"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Aastwiete",
+  "street": "Hohenzollerstra\u00dfe 76",
   "symptoms": [
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
+    "Halschmerzen",
     "Schnupfen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "784910"
+  "weakenedImmuneSystem": false,
+  "zip": "66091"
 }

--- a/server/src/main/resources/sample_data/persons/person90.json
+++ b/server/src/main/resources/sample_data/persons/person90.json
@@ -1,29 +1,32 @@
 {
-  "city": "Berlin",
-  "coronaContacts": false,
-  "dateOfBirth": "1999-07-21",
-  "email": "t.lange@posteo.de",
-  "firstName": "Tim",
+  "city": "Heusweiler",
+  "coronaContacts": true,
+  "dateOfBirth": "1930-07-13",
+  "email": "j.richter@gmx.de",
+  "firstName": "Jana",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 75,
-  "insuranceCompany": "DAK Gesundheit",
-  "insuranceMembershipNumber": "K977364141",
-  "lastName": "Lange",
+  "gender": "female",
+  "insuranceCompany": "IKK Nord",
+  "insuranceMembershipNumber": "Q786237617",
+  "lastName": "Richter",
   "nationality": "deutsch",
-  "phoneNumber": "43610110371",
+  "phoneNumber": "0334191825",
   "preIllnesses": [
-    ""
+    "Imunsystemschw\u00e4che"
   ],
   "riskAreas": [
-    "Tirol"
+    "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Haidth\u00f6heAarweg",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "S\u00fcdweg 25",
   "symptoms": [
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Husten",
+    "Schnupfen",
     "Gelenkschmerzen",
-    "Husten"
+    "Fieber"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "381070"
+  "weakenedImmuneSystem": true,
+  "zip": "66714"
 }

--- a/server/src/main/resources/sample_data/persons/person91.json
+++ b/server/src/main/resources/sample_data/persons/person91.json
@@ -1,33 +1,33 @@
 {
-  "city": "Bochum",
+  "city": "Homburg",
   "coronaContacts": true,
-  "dateOfBirth": "1988-07-25",
-  "email": "t.wagner@gmail.de",
-  "firstName": "Tim",
-  "fluImmunization": false,
+  "dateOfBirth": "1990-04-10",
+  "email": "f.weber@gmail.de",
+  "firstName": "Fin",
+  "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 56,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "C207873599",
-  "lastName": "Wagner",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "U286009450",
+  "lastName": "Weber",
   "nationality": "deutsch",
-  "phoneNumber": "2101021890910",
+  "phoneNumber": "1252866929",
   "preIllnesses": [
-    "Imunsystemschw\u00e4che"
-  ],
-  "riskAreas": [
     ""
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Haidth\u00f6heAarweg",
-  "symptoms": [
-    "Kopfschmerzen",
-    "Erk\u00e4ltung",
-    "Schnupfen",
-    "Fieber",
-    "Atemschwierigkeiten",
-    "Halschmerzen"
+  "riskAreas": [
+    "Hubei"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "531026"
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Z\u00e4hringerstra\u00dfe 54",
+  "symptoms": [
+    "Atemschwierigkeiten",
+    "Fieber",
+    "Halschmerzen",
+    "Schnupfen",
+    "Erk\u00e4ltung",
+    "Gelenkschmerzen",
+    "Husten"
+  ],
+  "weakenedImmuneSystem": true,
+  "zip": "662710"
 }

--- a/server/src/main/resources/sample_data/persons/person92.json
+++ b/server/src/main/resources/sample_data/persons/person92.json
@@ -1,29 +1,33 @@
 {
-  "city": "Hamburg",
-  "coronaContacts": false,
-  "dateOfBirth": "1928-09-07",
-  "email": "k.schulze@web.de",
-  "firstName": "Karl",
+  "city": "Saarlouis",
+  "coronaContacts": true,
+  "dateOfBirth": "1934-09-21",
+  "email": "a.richter@gmx.de",
+  "firstName": "Anna",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 76,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "S551898779",
-  "lastName": "Schulze",
+  "gender": "female",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "R409957384",
+  "lastName": "Richter",
   "nationality": "deutsch",
-  "phoneNumber": "64100376137",
+  "phoneNumber": "76107677219",
   "preIllnesses": [
-    ""
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    ""
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordtstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Aarhusweg 97",
   "symptoms": [
-    "Gelenkschmerzen",
-    "Halschmerzen"
+    "Fieber",
+    "Atemschwierigkeiten",
+    "Husten",
+    "Schnupfen",
+    "Halschmerzen",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "18055"
+  "weakenedImmuneSystem": false,
+  "zip": "66340"
 }

--- a/server/src/main/resources/sample_data/persons/person93.json
+++ b/server/src/main/resources/sample_data/persons/person93.json
@@ -1,28 +1,34 @@
 {
-  "city": "K\u00f6ln",
-  "coronaContacts": true,
-  "dateOfBirth": "1998-07-17",
-  "email": "k.schulze@t-online.de",
-  "firstName": "Karl",
-  "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 19,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "R450845460",
-  "lastName": "Schulze",
+  "city": "St. Ingbert",
+  "coronaContacts": false,
+  "dateOfBirth": "2001-08-09",
+  "email": "l.klein@gmail.de",
+  "firstName": "Lisa",
+  "fluImmunization": true,
+  "gender": "female",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "S476685251",
+  "lastName": "Klein",
   "nationality": "deutsch",
-  "phoneNumber": "410866611088",
+  "phoneNumber": "51713395910",
   "preIllnesses": [
-    "Krebserkrankung"
+    "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Tirol"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Schnell",
-  "street": "Nordstra\u00dfe",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Kaiserstra\u00dfe 21",
   "symptoms": [
-    "Atemschwierigkeiten"
+    "Schnupfen",
+    "Gelenkschmerzen",
+    "Kopfschmerzen",
+    "Halschmerzen",
+    "Atemschwierigkeiten",
+    "Erk\u00e4ltung",
+    "Fieber",
+    "Husten"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "41418"
+  "zip": "66923"
 }

--- a/server/src/main/resources/sample_data/persons/person94.json
+++ b/server/src/main/resources/sample_data/persons/person94.json
@@ -1,28 +1,31 @@
 {
-  "city": "Kiel",
-  "coronaContacts": false,
-  "dateOfBirth": "1991-08-20",
-  "email": "f.mueller@gmx.de",
-  "firstName": "Franz",
+  "city": "P\u00fcttlingen",
+  "coronaContacts": true,
+  "dateOfBirth": "1974-03-23",
+  "email": "k.weber@posteo.de",
+  "firstName": "Karl",
   "fluImmunization": true,
   "gender": "male",
-  "houseNumber": 63,
-  "insuranceCompany": "Barmer",
-  "insuranceMembershipNumber": "X938725480",
-  "lastName": "M\u00fcller",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "M653635749",
+  "lastName": "Weber",
   "nationality": "deutsch",
-  "phoneNumber": "904101021020",
+  "phoneNumber": "5310672910410",
   "preIllnesses": [
     ""
   ],
   "riskAreas": [
-    "Tirol"
+    "Moscow"
   ],
   "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Haidth\u00f6heAarweg",
+  "street": "Kaiserstra\u00dfe 48",
   "symptoms": [
+    "Gelenkschmerzen",
+    "Erk\u00e4ltung",
+    "Schnupfen",
+    "Atemschwierigkeiten",
     "Husten"
   ],
-  "weakenedImmuneSystem": false,
-  "zip": "58842"
+  "weakenedImmuneSystem": true,
+  "zip": "667110"
 }

--- a/server/src/main/resources/sample_data/persons/person95.json
+++ b/server/src/main/resources/sample_data/persons/person95.json
@@ -1,29 +1,25 @@
 {
-  "city": "Berlin",
-  "coronaContacts": true,
-  "dateOfBirth": "1940-06-02",
-  "email": "l.klein@gmx.de",
-  "firstName": "Lisa",
+  "city": "Saarbr\u00fccken",
+  "coronaContacts": false,
+  "dateOfBirth": "1937-07-07",
+  "email": "e.winkler@t-online.de",
+  "firstName": "Emma",
   "fluImmunization": true,
   "gender": "female",
-  "houseNumber": 94,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "L511221078",
-  "lastName": "Klein",
+  "insuranceCompany": "AOK",
+  "insuranceMembershipNumber": "U941695219",
+  "lastName": "Winkler",
   "nationality": "deutsch",
-  "phoneNumber": "79252419101",
+  "phoneNumber": "6374545892",
   "preIllnesses": [
     "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "New York"
+    "Moscow"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Schernerweg",
-  "symptoms": [
-    "Husten",
-    "Atemschwierigkeiten"
-  ],
-  "weakenedImmuneSystem": true,
-  "zip": "80003"
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Hohenzollerstra\u00dfe 62",
+  "symptoms": [],
+  "weakenedImmuneSystem": false,
+  "zip": "665100"
 }

--- a/server/src/main/resources/sample_data/persons/person96.json
+++ b/server/src/main/resources/sample_data/persons/person96.json
@@ -1,31 +1,27 @@
 {
-  "city": "M\u00fcnchen",
+  "city": "Riegelsberg",
   "coronaContacts": false,
-  "dateOfBirth": "1965-05-27",
-  "email": "t.schulze@gmx.de",
-  "firstName": "Tim",
+  "dateOfBirth": "1989-11-10",
+  "email": "j.sommer@posteo.de",
+  "firstName": "Jana",
   "fluImmunization": false,
-  "gender": "male",
-  "houseNumber": 51,
-  "insuranceCompany": "KNAPPSCHAFT",
-  "insuranceMembershipNumber": "O108556837",
-  "lastName": "Schulze",
+  "gender": "female",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "Y351410032",
+  "lastName": "Sommer",
   "nationality": "deutsch",
-  "phoneNumber": "19518100238",
+  "phoneNumber": "2411054151010",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    ""
   ],
   "riskAreas": [
-    "Hubei"
+    "GrandEst"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Aarhusweg",
+  "speedOfSymptomsOutbreak": "Schnell",
+  "street": "Abbachstra\u00dfe 6",
   "symptoms": [
-    "Atemschwierigkeiten",
-    "Kopfschmerzen",
-    "Gelenkschmerzen",
     "Fieber"
   ],
-  "weakenedImmuneSystem": true,
-  "zip": "17445"
+  "weakenedImmuneSystem": false,
+  "zip": "666104"
 }

--- a/server/src/main/resources/sample_data/persons/person97.json
+++ b/server/src/main/resources/sample_data/persons/person97.json
@@ -1,28 +1,34 @@
 {
-  "city": "Freiburg",
+  "city": "Bous",
   "coronaContacts": true,
-  "dateOfBirth": "1986-01-30",
-  "email": "k.winter@posteo.de",
-  "firstName": "Kai",
-  "fluImmunization": true,
+  "dateOfBirth": "1949-01-01",
+  "email": "b.klein@web.de",
+  "firstName": "Ben",
+  "fluImmunization": false,
   "gender": "male",
-  "houseNumber": 94,
-  "insuranceCompany": "IKK Nord",
-  "insuranceMembershipNumber": "B252872361",
-  "lastName": "Winter",
+  "insuranceCompany": "Barmer",
+  "insuranceMembershipNumber": "U827070406",
+  "lastName": "Klein",
   "nationality": "deutsch",
-  "phoneNumber": "603851005010",
+  "phoneNumber": "5162713611",
   "preIllnesses": [
     "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "GrandEst"
+    "Tirol"
   ],
-  "speedOfSymptomsOutbreak": "Mittel",
-  "street": "Niekampsweg",
+  "speedOfSymptomsOutbreak": "Langsam",
+  "street": "Schernerweg 40",
   "symptoms": [
-    "Husten"
+    "Husten",
+    "Atemschwierigkeiten",
+    "Kopfschmerzen",
+    "Fieber",
+    "Erk\u00e4ltung",
+    "Halschmerzen",
+    "Gelenkschmerzen",
+    "Schnupfen"
   ],
   "weakenedImmuneSystem": true,
-  "zip": "41383"
+  "zip": "66542"
 }

--- a/server/src/main/resources/sample_data/persons/person98.json
+++ b/server/src/main/resources/sample_data/persons/person98.json
@@ -1,29 +1,29 @@
 {
-  "city": "Bochum",
+  "city": "P\u00fcttlingen",
   "coronaContacts": false,
-  "dateOfBirth": "1931-02-17",
-  "email": "d.winkler@t-online.de",
-  "firstName": "Daniela",
+  "dateOfBirth": "1990-10-24",
+  "email": "d.schulze@posteo.de",
+  "firstName": "Daniel",
   "fluImmunization": true,
-  "gender": "female",
-  "houseNumber": 37,
-  "insuranceCompany": "Techniker Krankenkasse",
-  "insuranceMembershipNumber": "H180195016",
-  "lastName": "Winkler",
+  "gender": "male",
+  "insuranceCompany": "DAK Gesundheit",
+  "insuranceMembershipNumber": "A806957378",
+  "lastName": "Schulze",
   "nationality": "deutsch",
-  "phoneNumber": "210619906102",
+  "phoneNumber": "65652341013",
   "preIllnesses": [
-    "Herz-Kreislauf"
+    "Krebserkrankung"
   ],
   "riskAreas": [
-    "GrandEst"
+    "New York"
   ],
-  "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Schernerweg",
+  "speedOfSymptomsOutbreak": "Mittel",
+  "street": "Poststra\u00dfe 76",
   "symptoms": [
-    "Fieber",
+    "Erk\u00e4ltung",
+    "Kopfschmerzen",
     "Gelenkschmerzen"
   ],
   "weakenedImmuneSystem": false,
-  "zip": "45655"
+  "zip": "66994"
 }

--- a/server/src/main/resources/sample_data/persons/person99.json
+++ b/server/src/main/resources/sample_data/persons/person99.json
@@ -1,26 +1,25 @@
 {
-  "city": "Frankfurt",
+  "city": "Saarbr\u00fccken",
   "coronaContacts": true,
-  "dateOfBirth": "1960-04-15",
-  "email": "s.mueller@web.de",
+  "dateOfBirth": "1942-11-20",
+  "email": "s.schulze@posteo.de",
   "firstName": "Susanne",
   "fluImmunization": false,
   "gender": "female",
-  "houseNumber": 41,
-  "insuranceCompany": "AOK",
-  "insuranceMembershipNumber": "V420877774",
-  "lastName": "M\u00fcller",
+  "insuranceCompany": "KNAPPSCHAFT",
+  "insuranceMembershipNumber": "C114810579",
+  "lastName": "Schulze",
   "nationality": "deutsch",
-  "phoneNumber": "47411210490",
+  "phoneNumber": "1805526965",
   "preIllnesses": [
     "Herz-Kreislauf"
   ],
   "riskAreas": [
-    "Tirol"
+    ""
   ],
   "speedOfSymptomsOutbreak": "Langsam",
-  "street": "Schernerweg",
+  "street": "Poststra\u00dfe 87",
   "symptoms": [],
   "weakenedImmuneSystem": true,
-  "zip": "21356"
+  "zip": "66271"
 }


### PR DESCRIPTION
Latest `pilot` branch commit d13eff0fe29249c89ab48e480a3bab96d10d5ab8 raised the amount of person test data files expected by the server from 100 to 250. However, the commit does not include the additional data files, which results in the server failing to correctly initialize. Due to the premature exception in database population, no account data is inserted into the database, blocking login and rendering the system unusable.

This pull request comes with the missing data files such that the server can once again fire up correctly. It also supplies a fix to the `genPersons.py` script that is used to generate such test data, together with an extension such that the amount of sample files to generate can be supplied as a command line argument.