### PR TITLE
fixes #401, CSV-Export in PatientList

### DIFF
--- a/client/src/views/PatientList.vue
+++ b/client/src/views/PatientList.vue
@@ -451,14 +451,16 @@ export default Vue.extend({
         queryPromise
           .then((result) => {
             const header =
-              'ID;Vorname;Nachname;Geschlecht;Status;Geburtsdatum;Stadt;E-Mail;Telefonnummer;' +
-              'Straße;Hausnummer;Stadt;Versicherung;Versichertennummer'
+              'ID;Vorname;Nachname;Geschlecht;Status;Geburtsdatum;E-Mail;Telefonnummer;' +
+              'Straße;Hausnummer;PLZ;Stadt;Versicherung;Versichertennummer'
             const patients = result
               .map(
                 (patient: Patient) =>
-                  `${patient.id};${patient.firstName};${patient.lastName};${patient.gender};${patient.patientStatus};` +
-                  `${patient.dateOfBirth};${patient.city};${patient.email};${patient.phoneNumber};${patient.street};` +
-                  `${patient.houseNumber};${patient.city};${patient.insuranceCompany};${patient.insuranceMembershipNumber}`
+                  `${patient.id};${patient.firstName};${patient.lastName};${patient.gender};` +
+                  `${patient.patientStatus};${patient.dateOfBirth};${patient.email};` +
+                  `${patient.phoneNumber};${patient.street};${patient.houseNumber};` +
+                  `${patient.zip};${patient.city};${patient.insuranceCompany};` +
+                  `${patient.insuranceMembershipNumber}`
               )
               .join('\n')
             const filename =


### PR DESCRIPTION
In PatientList -> CSV exportieren:

* Duplikat "Stadt" entfernt
* PLZ eingefügt

Hausnummer ist noch drin, aber patient.houseNumber scheint nirgendwo erfasst zu werden. 
patient.houseNumber wird auch an anderer Stelle verwendet, null führt hier aber nur zu Extra-Spaces:

SendToQuarantine.vue, Z.193
```js
               const address = `${patient.street} ${patient.houseNumber} ${patient.zip} ${patient.city}`
```
PatientDetails.vue, Z.102:
```js
                    <td>{{ patient.street }} {{ patient.houseNumber }}</td>
```