### PR TITLE
Revert "run eslint annotations only on push or PR != from fork"

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,6 @@ jobs:
       with:
         java-version: 1.11
     - uses: actions/checkout@v2
-    - if: ${{ github.event_name == 'push' || ( github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository ) }}
-      uses: hallee/eslint-action@1.0.3
-      with:
-        repo-token: "${{secrets.GITHUB_TOKEN}}"
-        source-root: "client"
     - run: |
         git fetch --unshallow
         gradle build lint test


### PR DESCRIPTION
Leider haben wir nach diesem PR ein paar eslinting Fehler. Würde das mal temporär reverten und danach wieder reinnehmen.